### PR TITLE
fixed bug in exporting openssh private key to pem

### DIFF
--- a/lib/src/ssh_key_pair.dart
+++ b/lib/src/ssh_key_pair.dart
@@ -288,7 +288,7 @@ abstract class OpenSSHKeyPair implements SSHKeyPair {
 
     // pad with bytes 1, 2, 3, ...
     for (var i = 0; writer.length % 8 != 0; i++) {
-      writer.writeUint8(i);
+      writer.writeUint8(i + 1);
     }
 
     return OpenSSHKeyPairs.unencrypted(


### PR DESCRIPTION
openssh private key padding must start with 1 and not 0 as it was before (altho comments in code say to start with 1). 
If padding is needed, it must be a right-trimmed substring of '0x01020304050607', as noted in https://coolaj86.com/articles/the-openssh-private-key-format/

It used to produce keys with ssh-keygen would consider as 'invalid format' key, now it works as intended  