### PR TITLE
make chunkSize a parameter

### DIFF
--- a/lib/src/sftp/sftp_client.dart
+++ b/lib/src/sftp/sftp_client.dart
@@ -640,15 +640,19 @@ class SftpFile {
   /// operation or wait for it to complete.
   SftpFileWriter write(
     Stream<Uint8List> stream, {
+    int? chunkSize,
     int offset = 0,
     void Function(int total)? onProgress,
   }) {
-    return SftpFileWriter(this, stream, offset, onProgress);
+    return SftpFileWriter(this, stream, offset, onProgress, chunkSize);
   }
 
   /// Writes [data] to the file starting at [offset].
-  Future<void> writeBytes(Uint8List data, {int offset = 0}) async {
-    const maxChunkSize = 16 * 1024;
+  Future<void> writeBytes(
+    Uint8List data, {
+    int offset = 0,
+    int maxChunkSize = 16 * 1024,
+  }) async {
     var bytesSent = 0;
     final futures = <Future<void>>[];
     while (bytesSent < data.length) {


### PR DESCRIPTION
I have some issues with old (and maybe bad) servers.

Through a VPN when sending files, the only way to make an upload work without stopping it during the progress is to change the chunksize.
I did it "hard" in the library source code, but with this branch, I could more easily set it.

I don't have much knowledge about network, and I don't know if I respect or not a standard or a convention with this branch.

But here is my little contribution.