### PR TITLE
Support controlling of stream upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [upcoming]
+- `SftpFile.write` now returns a `SftpFileWriter` that can be used to control
+  the writing process.
+
 ## 2.7.3
 - Update README.md
 - Move cli into separate package.

--- a/example/sftp_upload.dart
+++ b/example/sftp_upload.dart
@@ -19,7 +19,7 @@ void main(List<String> args) async {
     mode: SftpFileOpenMode.truncate | SftpFileOpenMode.write,
   );
 
-  await file.write(File('local_file.txt').openRead().cast());
+  await file.write(File('local_file.txt').openRead().cast()).done;
   print('done');
 
   client.close();

--- a/example/sftp_write.dart
+++ b/example/sftp_write.dart
@@ -23,10 +23,7 @@ void main(List<String> args) async {
     mode: SftpFileOpenMode.create | SftpFileOpenMode.write,
   );
 
-  await file.write(
-    Stream.value(Utf8Encoder().convert('hello there!')),
-  );
-
+  await file.write(Stream.value(Utf8Encoder().convert('hello there!'))).done;
   await file.close();
 
   client.close();

--- a/lib/src/sftp/sftp_client.dart
+++ b/lib/src/sftp/sftp_client.dart
@@ -570,13 +570,15 @@ class SftpFile {
   }
 
   /// Writes [stream] to the file starting at [offset].
-  Future<void> write(
+  ///
+  /// Returns a [SftpFileWriter] that can be used to control the write
+  /// operation or wait for it to complete.
+  SftpFileWriter write(
     Stream<Uint8List> stream, {
     int offset = 0,
     void Function(int total)? onProgress,
-  }) async {
-    final writer = SftpFileWriter(this, stream, offset, onProgress);
-    await writer.done;
+  }) {
+    return SftpFileWriter(this, stream, offset, onProgress);
   }
 
   /// Writes [data] to the file starting at [offset].

--- a/lib/src/sftp/sftp_stream_io.dart
+++ b/lib/src/sftp/sftp_stream_io.dart
@@ -4,38 +4,85 @@ import 'dart:typed_data';
 import 'package:dartssh2/src/sftp/sftp_client.dart';
 import 'package:dartssh2/src/utils/stream.dart';
 
+/// The amount of data to send in a single SFTP packet.
+///
+/// From the SFTP spec it's safe to send up to 32KB of data in a single packet.
+/// To strike a balance between capability and performance, we choose 16KB.
 const chunkSize = 16 * 1024;
+
+/// The maximum amount of data that can be sent to the remote host without
+/// receiving an acknowledgement.
 const maxBytesOnTheWire = chunkSize * 64;
 
+/// Holds the state of a streaming write operation from [stream] to [file].
 class SftpFileWriter {
+  /// The remote file to write to.
   final SftpFile file;
 
+  /// The stream of data to write to [file].
   final Stream<Uint8List> stream;
 
+  /// The offset in [file] to start writing to.
   final int offset;
 
-  final Function(int)? onProgress;
+  /// Called when [bytes] of data have been successfully written to [file].
+  final Function(int bytes)? onProgress;
 
+  /// Creates a new [SftpFileWriter]. The upload process is started immediately
+  /// after construction.
   SftpFileWriter(this.file, this.stream, this.offset, this.onProgress) {
     _subscription =
-        stream.transform(MaxChunkSize(chunkSize)).listen(_onStreamData);
+        stream.transform(MaxChunkSize(chunkSize)).listen(_handleChunk);
 
-    _subscription.onDone(_onStreamDone);
+    _subscription.onDone(_handleStreamDone);
   }
 
+  /// The subscription for [stream]. We use this to pause and resume the data
+  /// source.
   late final StreamSubscription<Uint8List> _subscription;
 
   final _doneCompleter = Completer<void>();
 
+  /// Bytes of data that have been sent to the remote host. The difference
+  /// between this and [_bytesAcked] is the amount of data on the wire.
   var _bytesSent = 0;
 
+  /// Bytes of data that have been acknowledged by the remote host.
   var _bytesAcked = 0;
 
+  /// Whether [stream] has emitted all of its data.
   var _streamDone = false;
 
+  /// A [Future] that completes when:
+  ///
+  /// - All data from [stream] has been written to [file]
+  /// - Or the write operation has been aborted by calling [abort].
   Future<void> get done => _doneCompleter.future;
 
-  Future<void> _onStreamData(Uint8List chunk) async {
+  /// Stops [stream] from emitting more data. Returns a [Future] that completes
+  /// when the underlying data source of [stream] has been successfully closed.
+  ///
+  /// Calling [abort] will make [done] to complete immediately.
+  Future<void> abort() async {
+    _doneCompleter.complete();
+    await _subscription.cancel();
+  }
+
+  /// Pauses [stream] from emitting more data. It's safe to call this even if
+  /// the stream is already paused. Use [resume] to resume the operation.
+  void pause() {
+    if (!_subscription.isPaused) {
+      _subscription.pause();
+    }
+  }
+
+  /// Resumes [stream] after it has been paused. It's safe to call this even if
+  /// the stream is not paused. Use [pause] to pause the operation.
+  void resume() {
+    _subscription.resume();
+  }
+
+  Future<void> _handleChunk(Uint8List chunk) async {
     final bytesOnTheWire = _bytesSent - _bytesAcked;
     if (bytesOnTheWire >= maxBytesOnTheWire) {
       _subscription.pause();
@@ -57,7 +104,7 @@ class SftpFileWriter {
     }
   }
 
-  void _onStreamDone() {
+  void _handleStreamDone() {
     _streamDone = true;
   }
 }

--- a/lib/src/sftp/sftp_stream_io.dart
+++ b/lib/src/sftp/sftp_stream_io.dart
@@ -32,9 +32,9 @@ class SftpFileWriter {
   /// after construction.
   SftpFileWriter(this.file, this.stream, this.offset, this.onProgress) {
     _subscription =
-        stream.transform(MaxChunkSize(chunkSize)).listen(_handleChunk);
+        stream.transform(MaxChunkSize(chunkSize)).listen(_handleLocalData);
 
-    _subscription.onDone(_handleStreamDone);
+    _subscription.onDone(_handleLocalDone);
   }
 
   /// The subscription for [stream]. We use this to pause and resume the data
@@ -82,7 +82,7 @@ class SftpFileWriter {
     _subscription.resume();
   }
 
-  Future<void> _handleChunk(Uint8List chunk) async {
+  Future<void> _handleLocalData(Uint8List chunk) async {
     final bytesOnTheWire = _bytesSent - _bytesAcked;
     if (bytesOnTheWire >= maxBytesOnTheWire) {
       _subscription.pause();
@@ -104,7 +104,7 @@ class SftpFileWriter {
     }
   }
 
-  void _handleStreamDone() {
+  void _handleLocalDone() {
     _streamDone = true;
   }
 }

--- a/test/src/sftp/sftp_stream_io_test.dart
+++ b/test/src/sftp/sftp_stream_io_test.dart
@@ -1,0 +1,7 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('sftp stream io ...', () async {
+    // TODO: Implement test
+  });
+}

--- a/test/src/sftp/sftp_stream_io_test.dart
+++ b/test/src/sftp/sftp_stream_io_test.dart
@@ -1,7 +1,66 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('sftp stream io ...', () async {
-    // TODO: Implement test
+  late SSHClient client;
+
+  setUp(() async {
+    client = await getHoneypotClient();
   });
+
+  tearDown(() async {
+    client.close();
+    await client.done;
+  });
+
+  group('SftpFileWriter', () {
+    test('can pause & resume', () async {
+      final sftp = await client.sftp();
+
+      final dataController = StreamController<Uint8List>(
+        onListen: () => print('onListen'),
+        onPause: () => print('onPause'),
+        onResume: () => print('onResume'),
+        onCancel: () => print('onCancel'),
+      );
+      final dataToUpload = dataController.stream;
+
+      final file = await sftp.open(
+        'a.out',
+        mode: SftpFileOpenMode.create | SftpFileOpenMode.write,
+      );
+      final writer = file.write(dataToUpload);
+
+      dataController.add(Uint8List(100));
+
+      await Future.delayed(Duration(milliseconds: 1));
+      expect(dataController.isPaused, isFalse);
+
+      dataController.add(Uint8List(100));
+      writer.pause();
+
+      await Future.delayed(Duration(milliseconds: 1));
+      expect(dataController.isPaused, isTrue);
+
+      dataController.add(Uint8List(100));
+      writer.resume();
+
+      await Future.delayed(Duration(milliseconds: 1));
+      expect(dataController.isPaused, isFalse);
+
+      await dataController.close();
+      await writer.done;
+    });
+  });
+}
+
+Future<SSHClient> getHoneypotClient() async {
+  return SSHClient(
+    await SSHSocket.connect('honeypot.terminal.studio', 2222),
+    username: 'root',
+    onPasswordRequest: () => 'random',
+  );
 }


### PR DESCRIPTION
Before:
```dart
final sftp = await client.sftp();
final file = await sftp.open('path/to/file');
await file.write(<stream>);
awaut file.close();
```

After:
```dart
final sftp = await client.sftp();
final file = await sftp.open('path/to/file');
final writer = file.write(<stream>);
...
writer.pause();
...
writer.resume();
await writer.done;
awaut file.close();
```

TODO:
[ ] Add tests.