### PR TITLE
Fix: Socket Support on Web

### DIFF
--- a/lib/src/socket/ssh_socket_js.dart
+++ b/lib/src/socket/ssh_socket_js.dart
@@ -1,71 +1,9 @@
-import 'dart:async';
-import 'dart:typed_data';
-
 import 'package:dartssh2/src/socket/ssh_socket.dart';
-import 'package:socket_io_client/socket_io_client.dart';
 
 Future<SSHSocket> connectNativeSocket(
   String host,
   int port, {
   Duration? timeout,
 }) async {
-  // throw UnimplementedError("Native socket is not supported on web");
-
-  final socket = io('http://$host:$port');
-
-//When an event recieved from server, data is added to the stream
-  socket.on('event', (data) => streamSocket.addResponse);
-  socket.onDisconnect((_) => print('disconnect'));
-
-  return _SSHNativeSocket._(socket);
+  throw UnimplementedError("Native socket is not supported on web");
 }
-
-class _SSHNativeSocket implements SSHSocket {
-  final Socket _socket;
-
-  _SSHNativeSocket._(this._socket);
-
-  @override
-  Stream<Uint8List> get stream => streamSocket.getStream;
-
-  @override
-  StreamSink<List<int>> get sink => streamSocket.getSink;
-
-  @override
-  Future<void> close() async {
-    _socket.close();
-  }
-
-  @override
-  Future<void> get done => streamSocket.done;
-
-  @override
-  void destroy() {
-    _socket.destroy();
-  }
-
-  @override
-  String toString() {
-    final address = '${_socket.receiveBuffer}';
-    return '_SSHNativeSocket($address)';
-  }
-}
-
-// STEP1:  Stream setup
-class StreamSocket {
-  final _socketResponse = StreamController<Uint8List>();
-
-  void Function(Uint8List) get addResponse => _socketResponse.sink.add;
-
-  Stream<Uint8List> get getStream => _socketResponse.stream;
-
-  StreamSink<List<int>> get getSink => _socketResponse.sink;
-
-  Future<dynamic> get done => _socketResponse.done;
-
-  void dispose() {
-    _socketResponse.close();
-  }
-}
-
-StreamSocket streamSocket = StreamSocket();

--- a/lib/src/socket/ssh_socket_js.dart
+++ b/lib/src/socket/ssh_socket_js.dart
@@ -1,9 +1,71 @@
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:dartssh2/src/socket/ssh_socket.dart';
+import 'package:socket_io_client/socket_io_client.dart';
 
 Future<SSHSocket> connectNativeSocket(
   String host,
   int port, {
   Duration? timeout,
 }) async {
-  throw UnimplementedError("Native socket is not supported on web");
+  // throw UnimplementedError("Native socket is not supported on web");
+
+  final socket = io('http://$host:$port');
+
+//When an event recieved from server, data is added to the stream
+  socket.on('event', (data) => streamSocket.addResponse);
+  socket.onDisconnect((_) => print('disconnect'));
+
+  return _SSHNativeSocket._(socket);
 }
+
+class _SSHNativeSocket implements SSHSocket {
+  final Socket _socket;
+
+  _SSHNativeSocket._(this._socket);
+
+  @override
+  Stream<Uint8List> get stream => streamSocket.getStream;
+
+  @override
+  StreamSink<List<int>> get sink => streamSocket.getSink;
+
+  @override
+  Future<void> close() async {
+    _socket.close();
+  }
+
+  @override
+  Future<void> get done => streamSocket.done;
+
+  @override
+  void destroy() {
+    _socket.destroy();
+  }
+
+  @override
+  String toString() {
+    final address = '${_socket.receiveBuffer}';
+    return '_SSHNativeSocket($address)';
+  }
+}
+
+// STEP1:  Stream setup
+class StreamSocket {
+  final _socketResponse = StreamController<Uint8List>();
+
+  void Function(Uint8List) get addResponse => _socketResponse.sink.add;
+
+  Stream<Uint8List> get getStream => _socketResponse.stream;
+
+  StreamSink<List<int>> get getSink => _socketResponse.sink;
+
+  Future<dynamic> get done => _socketResponse.done;
+
+  void dispose() {
+    _socketResponse.close();
+  }
+}
+
+StreamSocket streamSocket = StreamSocket();

--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -637,8 +637,6 @@ class SSHTransport {
     switch (messageId) {
       case SSH_Message_KexInit.messageId:
         return _handleMessageKexInit(message);
-      case SSH_Message_KexDH_Init.messageId:
-        return _handleMessageKexDHInit(message);
       case SSH_Message_KexDH_Reply.messageId:
       case SSH_Message_KexDH_GexReply.messageId:
         return _handleMessageKexReply(message);
@@ -653,103 +651,6 @@ class SSHTransport {
     printDebug?.call('SSHTransport._handleMessageKexInit');
 
     final message = SSH_Message_KexInit.decode(payload);
-    printTrace?.call('<- $socket: $message');
-    _remoteKexInit = payload;
-
-    _kexType = SSHKexUtils.selectAlgorithm(
-      localAlgorithms: algorithms.kex,
-      remoteAlgorithms: message.kexAlgorithms,
-      isServer: isServer,
-    );
-    _hostkeyType = SSHKexUtils.selectAlgorithm(
-      localAlgorithms: algorithms.hostkey,
-      remoteAlgorithms: message.serverHostKeyAlgorithms,
-      isServer: isServer,
-    );
-    _clientCipherType = SSHKexUtils.selectAlgorithm(
-      localAlgorithms: algorithms.cipher,
-      remoteAlgorithms: message.encryptionClientToServer,
-      isServer: isServer,
-    );
-    _serverCipherType = SSHKexUtils.selectAlgorithm(
-      localAlgorithms: algorithms.cipher,
-      remoteAlgorithms: message.encryptionServerToClient,
-      isServer: isServer,
-    );
-    _clientMacType = SSHKexUtils.selectAlgorithm(
-      localAlgorithms: algorithms.mac,
-      remoteAlgorithms: message.macClientToServer,
-      isServer: isServer,
-    );
-    _serverMacType = SSHKexUtils.selectAlgorithm(
-      localAlgorithms: algorithms.mac,
-      remoteAlgorithms: message.macServerToClient,
-      isServer: isServer,
-    );
-
-    if (_kexType == null) {
-      throw StateError('No matching key exchange algorithm');
-    }
-    if (_hostkeyType == null) {
-      throw StateError('No matching host key algorithm');
-    }
-    if (_clientCipherType == null) {
-      throw StateError('No matching client cipher algorithm');
-    }
-    if (_serverCipherType == null) {
-      throw StateError('No matching server cipher algorithm');
-    }
-    if (_clientMacType == null) {
-      throw StateError('No matching client MAC algorithm');
-    }
-    if (_serverMacType == null) {
-      throw StateError('No matching server MAC algorithm');
-    }
-
-    printDebug?.call('SSHTransport._kexType: $_kexType');
-    printDebug?.call('SSHTransport._hostkeyType: $_hostkeyType');
-    printDebug?.call('SSHTransport._clientCipherType: $_clientCipherType');
-    printDebug?.call('SSHTransport._serverCipherType: $_serverCipherType');
-    printDebug?.call('SSHTransport._clientMacType: $_clientMacType');
-    printDebug?.call('SSHTransport._serverMacType: $_serverMacType');
-
-    switch (_kexType) {
-      case SSHKexType.x25519:
-        _kex = SSHKexX25519();
-        break;
-      case SSHKexType.nistp256:
-        _kex = SSHKexNist.p256();
-        break;
-      case SSHKexType.nistp384:
-        _kex = SSHKexNist.p384();
-        break;
-      case SSHKexType.nistp521:
-        _kex = SSHKexNist.p521();
-        break;
-      case SSHKexType.dh14Sha1:
-      case SSHKexType.dh14Sha256:
-        _kex = SSHKexDH.group14();
-        break;
-      case SSHKexType.dh1Sha1:
-        _kex = SSHKexDH.group1();
-        break;
-      case SSHKexType.dhGexSha1:
-      case SSHKexType.dhGexSha256:
-        if (isClient) _sendKexDHGexRequest();
-        return;
-      default:
-        throw UnimplementedError('$_kexType');
-    }
-
-    if (isClient) {
-      _sendKexDHInit();
-    }
-  }
-
-  void _handleMessageKexDHInit(Uint8List payload) {
-    printDebug?.call('SSHTransport._handleMessageKexDHInit');
-
-    final message = SSH_Message_KexDH_GexInit.decode(payload);
     printTrace?.call('<- $socket: $message');
     _remoteKexInit = payload;
 

--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -637,6 +637,8 @@ class SSHTransport {
     switch (messageId) {
       case SSH_Message_KexInit.messageId:
         return _handleMessageKexInit(message);
+      case SSH_Message_KexDH_Init.messageId:
+        return _handleMessageKexDHInit(message);
       case SSH_Message_KexDH_Reply.messageId:
       case SSH_Message_KexDH_GexReply.messageId:
         return _handleMessageKexReply(message);
@@ -651,6 +653,103 @@ class SSHTransport {
     printDebug?.call('SSHTransport._handleMessageKexInit');
 
     final message = SSH_Message_KexInit.decode(payload);
+    printTrace?.call('<- $socket: $message');
+    _remoteKexInit = payload;
+
+    _kexType = SSHKexUtils.selectAlgorithm(
+      localAlgorithms: algorithms.kex,
+      remoteAlgorithms: message.kexAlgorithms,
+      isServer: isServer,
+    );
+    _hostkeyType = SSHKexUtils.selectAlgorithm(
+      localAlgorithms: algorithms.hostkey,
+      remoteAlgorithms: message.serverHostKeyAlgorithms,
+      isServer: isServer,
+    );
+    _clientCipherType = SSHKexUtils.selectAlgorithm(
+      localAlgorithms: algorithms.cipher,
+      remoteAlgorithms: message.encryptionClientToServer,
+      isServer: isServer,
+    );
+    _serverCipherType = SSHKexUtils.selectAlgorithm(
+      localAlgorithms: algorithms.cipher,
+      remoteAlgorithms: message.encryptionServerToClient,
+      isServer: isServer,
+    );
+    _clientMacType = SSHKexUtils.selectAlgorithm(
+      localAlgorithms: algorithms.mac,
+      remoteAlgorithms: message.macClientToServer,
+      isServer: isServer,
+    );
+    _serverMacType = SSHKexUtils.selectAlgorithm(
+      localAlgorithms: algorithms.mac,
+      remoteAlgorithms: message.macServerToClient,
+      isServer: isServer,
+    );
+
+    if (_kexType == null) {
+      throw StateError('No matching key exchange algorithm');
+    }
+    if (_hostkeyType == null) {
+      throw StateError('No matching host key algorithm');
+    }
+    if (_clientCipherType == null) {
+      throw StateError('No matching client cipher algorithm');
+    }
+    if (_serverCipherType == null) {
+      throw StateError('No matching server cipher algorithm');
+    }
+    if (_clientMacType == null) {
+      throw StateError('No matching client MAC algorithm');
+    }
+    if (_serverMacType == null) {
+      throw StateError('No matching server MAC algorithm');
+    }
+
+    printDebug?.call('SSHTransport._kexType: $_kexType');
+    printDebug?.call('SSHTransport._hostkeyType: $_hostkeyType');
+    printDebug?.call('SSHTransport._clientCipherType: $_clientCipherType');
+    printDebug?.call('SSHTransport._serverCipherType: $_serverCipherType');
+    printDebug?.call('SSHTransport._clientMacType: $_clientMacType');
+    printDebug?.call('SSHTransport._serverMacType: $_serverMacType');
+
+    switch (_kexType) {
+      case SSHKexType.x25519:
+        _kex = SSHKexX25519();
+        break;
+      case SSHKexType.nistp256:
+        _kex = SSHKexNist.p256();
+        break;
+      case SSHKexType.nistp384:
+        _kex = SSHKexNist.p384();
+        break;
+      case SSHKexType.nistp521:
+        _kex = SSHKexNist.p521();
+        break;
+      case SSHKexType.dh14Sha1:
+      case SSHKexType.dh14Sha256:
+        _kex = SSHKexDH.group14();
+        break;
+      case SSHKexType.dh1Sha1:
+        _kex = SSHKexDH.group1();
+        break;
+      case SSHKexType.dhGexSha1:
+      case SSHKexType.dhGexSha256:
+        if (isClient) _sendKexDHGexRequest();
+        return;
+      default:
+        throw UnimplementedError('$_kexType');
+    }
+
+    if (isClient) {
+      _sendKexDHInit();
+    }
+  }
+
+  void _handleMessageKexDHInit(Uint8List payload) {
+    printDebug?.call('SSHTransport._handleMessageKexDHInit');
+
+    final message = SSH_Message_KexDH_GexInit.decode(payload);
     printTrace?.call('<- $socket: $message');
     _remoteKexInit = payload;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   meta: ^1.1.6
   pointycastle: ^3.0.0
   pinenacl: ^0.5.0
-  socket_io_client: ^2.0.1
 
 dev_dependencies:
   build_runner: ^2.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   meta: ^1.1.6
   pointycastle: ^3.0.0
   pinenacl: ^0.5.0
+  socket_io_client: ^2.0.1
 
 dev_dependencies:
   build_runner: ^2.1.1


### PR DESCRIPTION
I modified [ssh_socket_js.dart](https://github.com/14h4i/dartssh2/blob/master/lib/src/socket/ssh_socket_js.dart) and it maybe work for web.

However, I am having problems in:
https://github.com/TerminalStudio/dartssh2/blob/ae5447913eb92478f186a8db1a890826a1456311/lib/src/ssh_transport.dart#L635-L648
and
https://github.com/TerminalStudio/dartssh2/blob/ae5447913eb92478f186a8db1a890826a1456311/lib/src/ssh_client.dart#L489-L533

When run web with after modified, there is a case  `messageId` return with value 30 and it seems that the case has not been handled.
@xtyxtyx Can you help me to handle it. I don't know the logic of this part code.