### PR TITLE
SSH RSA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 <!-- Title-->
 <p align="center">
-  <h1 align="center">DartSSH 2</h1>
+  <h1 align="center">DartSSH 2 (ssh-rsa support)</h1>
+</p>
+
+<p align="center">
+  <h2 align="center">NOTE 1: this fork reverts an old commit that dropped support of ssh-rsa.
+    
+  NOTE2: THIS ISN'T SECURE, SO USE WITH CAUTION!</h2>
 </p>
 
 <!-- Badges-->

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   convert: ^3.0.0
   meta: ^1.1.6
   pointycastle: ^3.0.0
-  pinenacl: ^0.5.0
+  pinenacl: ^0.3.4
 
 dev_dependencies:
   build_runner: ^2.1.1


### PR DESCRIPTION
This patch latest known version of dartssh2 with support of the deprecated ssh-rsa algorithm.