### PR TITLE
Providing `SSHClient` on `onAuthenticated` callback and Environment Variables feature

### DIFF
--- a/lib/src/ssh_client.dart
+++ b/lib/src/ssh_client.dart
@@ -36,7 +36,7 @@ typedef SSHUserInfoRequestHandler = FutureOr<List<String>?> Function(
 /// https://datatracker.ietf.org/doc/html/rfc4252#section-5.4
 typedef SSHUserauthBannerHandler = void Function(String banner);
 
-typedef SSHAuthenticatedHandler = void Function();
+typedef SSHAuthenticatedHandler = void Function(SSHClient);
 
 typedef SSHRemoteConnectionFilter = bool Function(String host, int port);
 
@@ -559,7 +559,7 @@ class SSHClient {
     printTrace?.call('<- $socket: SSH_Message_Userauth_Success');
     printDebug?.call('SSHClient._handleUserauthSuccess');
     _authenticated.complete();
-    onAuthenticated?.call();
+    onAuthenticated?.call(this);
     _keepAlive?.start();
   }
 


### PR DESCRIPTION
Before this, I have to do this trick with a `Completer` as we can't use `client` on its own definition:
```dart
final socket = await SSHSocket.connect(_remoteSshHost, 22);
final authenticatedCompleter = Completer();
final client = SSHClient(
  socket,
  username: _remoteSshUser,
  identities: SSHKeyPair.fromPem(
    cc.read(sshPrivateKeyFileCapsule).readAsStringSync(),
  ),
  onAuthenticated: () {
    authenticatedCompleter.complete();
  },
);
print('Authenticating to SSH repository');

await authenticatedCompleter.future;
```