### PR TITLE
Use SHA256 instead of MD5 for fingerprints

### DIFF
--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -31,7 +31,7 @@ typedef SSHPrintHandler = void Function(String?);
 
 /// Function called when host key is received.
 /// [type] is the type of the host key, For example 'ssh-rsa',
-/// [fingerprint] md5 fingerprint of the host key.
+/// [fingerprint] SHA256 fingerprint of the host key.
 typedef SSHHostkeyVerifyHandler = FutureOr<bool> Function(
   String type,
   Uint8List fingerprint,
@@ -1180,7 +1180,7 @@ class SSHTransport {
     _sessionId ??= exchangeHash;
     _sharedSecret = sharedSecret;
 
-    final fingerprint = MD5Digest().process(hostkey);
+    final fingerprint = SHA256Digest().process(hostkey);
 
     if (_hostkeyVerified) {
       _sendNewKeys();


### PR DESCRIPTION
This is OpenSSH's default since [OpenSSH 6.8](https://www.openssh.com/txt/release-6.8). This makes it possible to verify fingerprints with `onVerifyHostKey` when logging into servers running this or higher versions of OpenSSH.