### PR TITLE
feat(pty): expose terminal modes in SSHPtyConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+- Added `SSHPtyConfig.modes` (`Map<int, int>?`) for sending RFC 4254 §8 terminal modes at pty-req time; wired through `SSHClient.shell()` and `SSHClient.execute()` via the existing `terminalModes` parameter of `sendPtyReq`. Common use: `{53: 0}` to disable ECHO at PTY creation, so callers injecting shell setup don't race against `stty -echo`. Default behavior unchanged when `modes` is omitted.
+
 ## [2.17.1] - 2026-04-12
 - Made `SSHPem.decode` accept CRLF (`\r\n`) line endings in addition to LF when parsing PEM content [#157]. Thanks [@gkc].
 

--- a/lib/src/ssh_client.dart
+++ b/lib/src/ssh_client.dart
@@ -69,9 +69,9 @@ class SSHPtyConfig {
   /// Height of the terminal in pixels. 0 if unknown.
   final int pixelHeight;
 
-  /// Terminal modes (termios opcode -> value). See RFC 4254 §8.            // <--- 추가
-  /// Example: `{53: 0}` to disable echo (ECHO opcode = 53).                // <--- 추가
-  final Map<int, int>? modes;                                            // <--- 추가
+  /// Terminal modes to apply at pty-req time (termios opcode -> value).
+  /// See RFC 4254 §8. Example: `{53: 0}` to disable echo (ECHO opcode = 53).
+  final Map<int, int>? modes;
 
   const SSHPtyConfig({
     this.type = 'xterm-256color',
@@ -79,25 +79,27 @@ class SSHPtyConfig {
     this.height = 24,
     this.pixelWidth = 0,
     this.pixelHeight = 0,
-    this.modes,                                                          // <--- 추가
+    this.modes,
   });
 
-  /// Encode modes to "encoded terminal modes" per RFC 4254 §8 —          // <--- 추가
-  /// opcode(1) + value(4, big-endian) per entry, terminated by 0x00.    // <--- 추가
-  Uint8List encodeModes() {                                              // <--- 추가
-    final m = modes;                                                     // <--- 추가
-    if (m == null || m.isEmpty) return Uint8List(0);                     // <--- 추가
-    final bb = BytesBuilder();                                           // <--- 추가
-    m.forEach((op, v) {                                                  // <--- 추가
-      bb.addByte(op & 0xff);                                             // <--- 추가
-      bb.addByte((v >> 24) & 0xff);                                      // <--- 추가
-      bb.addByte((v >> 16) & 0xff);                                      // <--- 추가
-      bb.addByte((v >> 8) & 0xff);                                       // <--- 추가
-      bb.addByte(v & 0xff);                                              // <--- 추가
-    });                                                                  // <--- 추가
-    bb.addByte(0); // TTY_OP_END                                         // <--- 추가
-    return bb.toBytes();                                                 // <--- 추가
-  }                                                                      // <--- 추가
+  /// Encodes [modes] into the "encoded terminal modes" byte string defined
+  /// by RFC 4254 §8 — each entry is opcode(1) + value(4, big-endian),
+  /// terminated by TTY_OP_END (0x00). Returns an empty list when [modes] is
+  /// null or empty (preserving prior pre-modes behavior).
+  Uint8List encodeModes() {
+    final m = modes;
+    if (m == null || m.isEmpty) return Uint8List(0);
+    final bb = BytesBuilder();
+    m.forEach((op, v) {
+      bb.addByte(op & 0xff);
+      bb.addByte((v >> 24) & 0xff);
+      bb.addByte((v >> 16) & 0xff);
+      bb.addByte((v >> 8) & 0xff);
+      bb.addByte(v & 0xff);
+    });
+    bb.addByte(0); // TTY_OP_END
+    return bb.toBytes();
+  }
 }
 
 class SSHX11Config {
@@ -482,7 +484,7 @@ class SSHClient {
         terminalHeight: pty.height,
         terminalPixelWidth: pty.pixelWidth,
         terminalPixelHeight: pty.pixelHeight,
-        terminalModes: pty.encodeModes(),                                // <--- 추가
+        terminalModes: pty.encodeModes(),
       );
       if (!ptyOk) {
         channelController.close();
@@ -550,7 +552,7 @@ class SSHClient {
         terminalHeight: pty.height,
         terminalPixelWidth: pty.pixelWidth,
         terminalPixelHeight: pty.pixelHeight,
-        terminalModes: pty.encodeModes(),                                // <--- 추가
+        terminalModes: pty.encodeModes(),
       );
       if (!ok) {
         channelController.close();

--- a/lib/src/ssh_client.dart
+++ b/lib/src/ssh_client.dart
@@ -69,13 +69,35 @@ class SSHPtyConfig {
   /// Height of the terminal in pixels. 0 if unknown.
   final int pixelHeight;
 
+  /// Terminal modes (termios opcode -> value). See RFC 4254 §8.            // <--- 추가
+  /// Example: `{53: 0}` to disable echo (ECHO opcode = 53).                // <--- 추가
+  final Map<int, int>? modes;                                            // <--- 추가
+
   const SSHPtyConfig({
     this.type = 'xterm-256color',
     this.width = 80,
     this.height = 24,
     this.pixelWidth = 0,
     this.pixelHeight = 0,
+    this.modes,                                                          // <--- 추가
   });
+
+  /// Encode modes to "encoded terminal modes" per RFC 4254 §8 —          // <--- 추가
+  /// opcode(1) + value(4, big-endian) per entry, terminated by 0x00.    // <--- 추가
+  Uint8List encodeModes() {                                              // <--- 추가
+    final m = modes;                                                     // <--- 추가
+    if (m == null || m.isEmpty) return Uint8List(0);                     // <--- 추가
+    final bb = BytesBuilder();                                           // <--- 추가
+    m.forEach((op, v) {                                                  // <--- 추가
+      bb.addByte(op & 0xff);                                             // <--- 추가
+      bb.addByte((v >> 24) & 0xff);                                      // <--- 추가
+      bb.addByte((v >> 16) & 0xff);                                      // <--- 추가
+      bb.addByte((v >> 8) & 0xff);                                       // <--- 추가
+      bb.addByte(v & 0xff);                                              // <--- 추가
+    });                                                                  // <--- 추가
+    bb.addByte(0); // TTY_OP_END                                         // <--- 추가
+    return bb.toBytes();                                                 // <--- 추가
+  }                                                                      // <--- 추가
 }
 
 class SSHX11Config {
@@ -460,6 +482,7 @@ class SSHClient {
         terminalHeight: pty.height,
         terminalPixelWidth: pty.pixelWidth,
         terminalPixelHeight: pty.pixelHeight,
+        terminalModes: pty.encodeModes(),                                // <--- 추가
       );
       if (!ptyOk) {
         channelController.close();
@@ -527,6 +550,7 @@ class SSHClient {
         terminalHeight: pty.height,
         terminalPixelWidth: pty.pixelWidth,
         terminalPixelHeight: pty.pixelHeight,
+        terminalModes: pty.encodeModes(),                                // <--- 추가
       );
       if (!ok) {
         channelController.close();


### PR DESCRIPTION
  ## Summary

  Adds an optional `modes: Map<int, int>?` field to `SSHPtyConfig` and wires it through `SSHClient.shell()` and
  `SSHClient.execute()` via the existing `terminalModes` parameter of `sendPtyReq` — which previously had no
  public API to populate.
  
  ## Motivation

  The SSH `pty-req` message (RFC 4254 §8) carries an "encoded terminal modes" field — opcode/value pairs that
  let the client request specific termios settings *at PTY creation time*. Without exposing this at the API
  level, callers have no way to control PTY behavior before the first byte hits the line discipline.
  
  The concrete use case that motivated this: a terminal client that injects shell integration (OSC 7 cwd
  reporting, prompt hooks) right after connection. Doing `client.shell()` then writing `stty -echo; <setup>;
  stty echo\n` doesn't work — the PTY echoes input character-by-character until the newline arrives, by which
  time the entire setup line has already been streamed to the user's screen. The only race-free fix is to
  disable ECHO **before** the PTY is created, which requires sending mode 53 (`ECHO`) with value 0 in the
  initial `pty-req`.

  Other common uses: `{51: 0, 53: 0}` for raw-mode TUIs, custom `VINTR`/`VERASE` mappings, etc.

  ## Changes
  
  - `SSHPtyConfig`: new `final Map<int, int>? modes` field and constructor parameter.
  - `SSHPtyConfig.encodeModes()`: encodes the map into the byte string format defined by RFC 4254 §8 —
  `opcode(1) + value(4 BE)` per entry, terminated by `TTY_OP_END` (0x00). Returns `Uint8List(0)` when `modes` is
   null or empty.
  - `SSHClient.shell()` and `SSHClient.execute()`: pass `pty.encodeModes()` as `terminalModes` to `sendPtyReq`.

  ## Backward compatibility

  Fully backward compatible. `modes` is optional and defaults to `null`; `encodeModes()` returns an empty byte
  string in that case, which is identical to the previous behavior (`sendPtyReq` already defaulted
  `terminalModes` to `Uint8List(0)`).
  
  ## Example

  ```dart
  final session = await client.shell(
    pty: const SSHPtyConfig(
      type: 'xterm-256color',
      width: 120,
      height: 40,
      modes: {53: 0}, // ECHO off at PTY creation
    ),
  );
  ```
  
  ## Spec
  RFC 4254 §8 — <https://datatracker.ietf.org/doc/html/rfc4254#section-8>
