### PR TITLE
docs: Add TealKit to "Built with dartssh2" showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as e
     <td style="text-align: center;">
       <b><a href="https://github.com/jc-hk-1916/NaviTerm">Naviterm</a></b>
     </td>
+    <!-- TealKit -->
+    <td style="text-align: center;">
+      <b><a href="https://github.com/lschaffer/tealkit">TealKit</a></b>
+    </td>
   </tr>
 
   <tr> 
@@ -75,12 +79,16 @@ SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as e
         <img src="https://raw.githubusercontent.com/jc-hk-1916/NaviTerm/main/images/1.png" width="300px" alt="Your all-in-one SSH terminal, SFTP client, and port forwarding tool, built from the ground up for macOS, iPhone, and iPad.">
       </a>
     </td>
+    <!-- TealKit -->
+    <td>
+      <a href="https://github.com/lschaffer/tealkit">
+        <img src="images/repo/desktop_playground_ssh_test.png" width="500px" alt="TealKit multiplatform agentic AI platform utilizing isolated SSH tools">
+      </a>
+    </td>
   </tr>
 </table>
 
-
 > Feel free to add your own app here by opening a pull request.
-
 
 
 ## 🧪 Try

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as e
     <!-- TealKit -->
     <td>
       <a href="https://github.com/lschaffer/tealkit">
-        <img src="images/repo/desktop_playground_ssh_test.png" width="500px" alt="TealKit multiplatform agentic AI platform utilizing isolated SSH tools">
+        <img src="https://github.com/lschaffer/tealkit/blob/master/images/repo/desktop_playground_ssh_test.png" width="500px" alt="TealKit multiplatform agentic AI platform utilizing isolated SSH tools">
       </a>
     </td>
   </tr>


### PR DESCRIPTION
Hi TerminalStudio team,

First of all, thank you for maintaining `dartssh2`—it has been an incredibly reliable foundation for building native SSH capabilities in the Dart/Flutter ecosystem.

I would love to add my project, **TealKit**, to the "Built with dartssh2" section in the README. 

### About the Project
[TealKit](https://github.com/lschaffer/tealkit) is a multiplatform (Windows/Mac/Linux/iOS/Android) agentic AI platform and headless server. It heavily utilizes `dartssh2` to provide an inline SSH tool execution layer, allowing AI micro-agents to run terminal commands, manage servers, and automate workflows natively. 

I have updated the showcase table in the README to add TealKit as a 5th column and included a neat preview screenshot of the agentic terminal execution in action. 

Thank you for your time and consideration!