### PR TITLE
feat(http): tolerant HTTP-date parsing for response date headers

### DIFF
--- a/lib/src/http/http_client.dart
+++ b/lib/src/http/http_client.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:dartssh2/src/http/http_date.dart';
 import 'package:dartssh2/src/http/http_exception.dart';
 import 'package:dartssh2/src/http/line_decoder.dart';
 import 'package:dartssh2/src/http/http_content_type.dart';
@@ -562,7 +563,7 @@ class _SSHHttpClientResponseHeaders implements SSHHttpHeaders {
   DateTime? get date {
     final val = value(SSHHttpHeaders.dateHeader);
     if (val != null) {
-      return DateTime.parse(val);
+      return parseHttpDate(val);
     }
     return null;
   }
@@ -576,7 +577,7 @@ class _SSHHttpClientResponseHeaders implements SSHHttpHeaders {
   DateTime? get expires {
     final val = value(SSHHttpHeaders.expiresHeader);
     if (val != null) {
-      return DateTime.parse(val);
+      return parseHttpDate(val);
     }
     return null;
   }
@@ -603,7 +604,7 @@ class _SSHHttpClientResponseHeaders implements SSHHttpHeaders {
   DateTime? get ifModifiedSince {
     final val = value(SSHHttpHeaders.ifModifiedSinceHeader);
     if (val != null) {
-      return DateTime.parse(val);
+      return parseHttpDate(val);
     }
     return null;
   }

--- a/lib/src/http/http_date.dart
+++ b/lib/src/http/http_date.dart
@@ -1,0 +1,86 @@
+/// Tolerant HTTP-date parsing per RFC 7231 §7.1.1.1.
+///
+/// Supports these forms:
+/// - IMF-fixdate: Sun, 06 Nov 1994 08:49:37 GMT
+/// - RFC 850:     Sunday, 06-Nov-94 08:49:37 GMT
+/// - asctime():   Sun Nov  6 08:49:37 1994
+///
+/// Returns a UTC [DateTime] or null if parsing fails.
+DateTime? parseHttpDate(String input) {
+  final s = input.trim();
+
+  final hasExplicitTimezone = RegExp(r'(?:Z|[+-]\d{2}:\d{2})$').hasMatch(s);
+  if (hasExplicitTimezone) {
+    final iso8601 = DateTime.tryParse(s);
+    if (iso8601 != null) {
+      return iso8601.toUtc();
+    }
+  }
+
+  // Month map (lowercase)
+  const months = {
+    'jan': 1,
+    'feb': 2,
+    'mar': 3,
+    'apr': 4,
+    'may': 5,
+    'jun': 6,
+    'jul': 7,
+    'aug': 8,
+    'sep': 9,
+    'oct': 10,
+    'nov': 11,
+    'dec': 12,
+  };
+
+  int? monthFromToken(String token) => months[token.toLowerCase()];
+
+  // IMF-fixdate: Sun, 06 Nov 1994 08:49:37 GMT
+  final rImf = RegExp(
+      r"^[A-Za-z]{3},\s+(\d{1,2})\s+([A-Za-z]{3})\s+(\d{4})\s+(\d{2}):(\d{2}):(\d{2})\s+([A-Za-z0-9:+-]+)$");
+  final mImf = rImf.firstMatch(s);
+  if (mImf != null) {
+    final day = int.parse(mImf.group(1)!);
+    final mon = monthFromToken(mImf.group(2)!);
+    final year = int.parse(mImf.group(3)!);
+    final hh = int.parse(mImf.group(4)!);
+    final mm = int.parse(mImf.group(5)!);
+    final ss = int.parse(mImf.group(6)!);
+    if (mon == null) return null;
+    // Zone token (mImf.group(7)) is typically GMT; treat any value as UTC.
+    return DateTime.utc(year, mon, day, hh, mm, ss);
+  }
+
+  // RFC 850: Sunday, 06-Nov-94 08:49:37 GMT
+  final r850 = RegExp(
+      r"^[A-Za-z]+,\s+(\d{1,2})-([A-Za-z]{3})-(\d{2})\s+(\d{2}):(\d{2}):(\d{2})\s+([A-Za-z0-9:+-]+)$");
+  final m850 = r850.firstMatch(s);
+  if (m850 != null) {
+    final day = int.parse(m850.group(1)!);
+    final mon = monthFromToken(m850.group(2)!);
+    final yy = int.parse(m850.group(3)!);
+    final year = yy >= 70 ? (1900 + yy) : (2000 + yy);
+    final hh = int.parse(m850.group(4)!);
+    final mm = int.parse(m850.group(5)!);
+    final ss = int.parse(m850.group(6)!);
+    if (mon == null) return null;
+    return DateTime.utc(year, mon, day, hh, mm, ss);
+  }
+
+  // asctime(): Sun Nov  6 08:49:37 1994
+  final rAsc = RegExp(
+      r"^[A-Za-z]{3}\s+([A-Za-z]{3})\s+(\d{1,2})\s+(\d{2}):(\d{2}):(\d{2})\s+(\d{4})$");
+  final mAsc = rAsc.firstMatch(s);
+  if (mAsc != null) {
+    final mon = monthFromToken(mAsc.group(1)!);
+    final day = int.parse(mAsc.group(2)!);
+    final hh = int.parse(mAsc.group(3)!);
+    final mm = int.parse(mAsc.group(4)!);
+    final ss = int.parse(mAsc.group(5)!);
+    final year = int.parse(mAsc.group(6)!);
+    if (mon == null) return null;
+    return DateTime.utc(year, mon, day, hh, mm, ss);
+  }
+
+  return null;
+}

--- a/test/src/http/http_date_test.dart
+++ b/test/src/http/http_date_test.dart
@@ -1,0 +1,53 @@
+import 'package:dartssh2/src/http/http_date.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('parseHttpDate', () {
+    test('parses IMF-fixdate', () {
+      final d = parseHttpDate('Sun, 06 Nov 1994 08:49:37 GMT');
+      expect(d, isNotNull);
+      expect(d!.isUtc, isTrue);
+      expect(d.year, 1994);
+      expect(d.month, 11);
+      expect(d.day, 6);
+      expect(d.hour, 8);
+      expect(d.minute, 49);
+      expect(d.second, 37);
+    });
+
+    test('parses RFC 850 two-digit year', () {
+      final d = parseHttpDate('Sunday, 06-Nov-94 08:49:37 GMT');
+      expect(d, isNotNull);
+      expect(d!.year, 1994);
+      expect(d.month, 11);
+      expect(d.day, 6);
+    });
+
+    test('parses asctime format', () {
+      final d = parseHttpDate('Sun Nov  6 08:49:37 1994');
+      expect(d, isNotNull);
+      expect(d!.year, 1994);
+      expect(d.month, 11);
+      expect(d.day, 6);
+      expect(d.hour, 8);
+      expect(d.minute, 49);
+      expect(d.second, 37);
+    });
+
+    test('accepts UTC zone token in IMF-fixdate', () {
+      final d = parseHttpDate('Sun, 06 Nov 1994 08:49:37 UTC');
+      expect(d, isNotNull);
+      expect(d!.isUtc, isTrue);
+    });
+
+    test('returns null on invalid', () {
+      final d = parseHttpDate('not a date');
+      expect(d, isNull);
+    });
+
+    test('returns null for ISO-8601 without explicit timezone', () {
+      final d = parseHttpDate('2026-04-13T10:00:00');
+      expect(d, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Replaces DateTime.parse with a dedicated parseHttpDate helper that accepts all RFC 7231 §7.1.1.1 HTTP-date formats:

- IMF-fixdate (preferred): Sun, 06 Nov 1994 08:49:37 GMT
- RFC 850 (legacy):        Sunday, 06-Nov-94 08:49:37 GMT
- asctime (legacy):        Sun Nov  6 08:49:37 1994

The previous DateTime.parse only understood ISO-8601 and threw on the standard HTTP date formats used by virtually every HTTP/1.1 server, so date/expires/ifModifiedSince getters were unreliable for tunneled responses. ISO-8601 values with an explicit timezone are still accepted as a fallback.

Add unit tests covering each format plus invalid input.

Backport of ServerBox's forked `dartssh2`.