### PR TITLE
feat(http): add chunked transfer-encoding decoding for response bodies

### DIFF
--- a/lib/src/http/http_client.dart
+++ b/lib/src/http/http_client.dart
@@ -413,27 +413,110 @@ class SSHHttpClientResponse {
     var inBody = false;
     var contentLength = 0;
     var contentRead = 0;
+    var finished = false;
+
+    // Chunked transfer encoding state (RFC 7230 §4.1).
+    var chunked = false;
+    var expectingChunkSize = false;
+    var expectingChunkData = false;
+    var expectingChunkCRLF = false;
+    var inTrailers = false;
+    var currentChunkSize = 0;
 
     void processLine(String line, int bytesRead, LineDecoder decoder) {
       final normalizedLine = line.trimRight();
       if (inBody) {
-        body.write(line);
-        contentRead += bytesRead;
+        if (chunked) {
+          if (expectingChunkSize) {
+            final trimmed = line.trim();
+            // Allow optional chunk extensions: <size>;(extension...)
+            final semi = trimmed.indexOf(';');
+            final sizeStr = (semi >= 0 ? trimmed.substring(0, semi) : trimmed);
+            currentChunkSize = int.parse(sizeStr, radix: 16);
+            if (currentChunkSize == 0) {
+              // Last-chunk; proceed to optional trailer headers terminated
+              // by a blank line.
+              expectingChunkSize = false;
+              inTrailers = true;
+              return;
+            }
+            // Read exactly currentChunkSize bytes for chunk data.
+            expectingChunkSize = false;
+            expectingChunkData = true;
+            decoder.expectedByteCount = currentChunkSize;
+            return;
+          }
+          if (expectingChunkData) {
+            // Append chunk data (decoded as UTF-8 text).
+            body.write(line);
+            expectingChunkData = false;
+            expectingChunkCRLF = true;
+            // Consume trailing CRLF after chunk data.
+            decoder.expectedByteCount = 2;
+            return;
+          }
+          if (expectingChunkCRLF) {
+            // Ignore CRLF and expect next chunk size line.
+            expectingChunkCRLF = false;
+            expectingChunkSize = true;
+            return;
+          }
+          if (inTrailers) {
+            // Read trailers until blank line, then finish.
+            if (line.trim().isEmpty) {
+              finished = true;
+            } else {
+              // Store trailer headers if needed.
+              final separator = line.indexOf(':');
+              if (separator > 0) {
+                final name =
+                    line.substring(0, separator).toLowerCase().trim();
+                final value = line.substring(separator + 1).trim();
+                headers.putIfAbsent(name, () => []).add(value);
+              }
+            }
+            return;
+          }
+          // Should not reach here under normal chunked flow.
+          return;
+        } else {
+          body.write(line);
+          contentRead += bytesRead;
+        }
       } else if (inHeader) {
         if (normalizedLine.trim().isEmpty) {
           inBody = true;
-          if (contentLength > 0) {
-            decoder.expectedByteCount = contentLength;
+          // Decide body framing.
+          final te = headers[SSHHttpHeaders.transferEncodingHeader]
+              ?.join(',')
+              .toLowerCase();
+          if (te != null && te.contains('chunked')) {
+            chunked = true;
+            expectingChunkSize = true;
+          } else {
+            // Identity transfer; use Content-Length when provided.
+            if (contentLength > 0) {
+              decoder.expectedByteCount = contentLength;
+            }
           }
           return;
         }
         final separator = normalizedLine.indexOf(':');
+        if (separator <= 0) {
+          throw FormatException(
+            'Invalid header line: "$normalizedLine" - no colon separator found',
+          );
+        }
         final name =
             normalizedLine.substring(0, separator).toLowerCase().trim();
         final value = normalizedLine.substring(separator + 1).trim();
+        final normalizedValue = value.toLowerCase();
         if (name == SSHHttpHeaders.transferEncodingHeader &&
-            value.toLowerCase() != 'identity') {
-          throw UnsupportedError('only identity transfer encoding is accepted');
+            normalizedValue != 'identity' &&
+            normalizedValue != 'chunked') {
+          throw UnsupportedError(
+            "only 'identity' or 'chunked' transfer encodings are accepted: $normalizedValue",
+          );
         }
         if (name == SSHHttpHeaders.contentLengthHeader) {
           contentLength = int.parse(value);
@@ -457,13 +540,15 @@ class SSHHttpClientResponse {
     final lineDecoder = LineDecoder.withCallback(processLine);
 
     await for (final chunk in socket.stream) {
-      if (!inHeader ||
-          !inBody ||
-          ((contentRead + lineDecoder.bufferedBytes) < contentLength)) {
-        lineDecoder.add(chunk);
-        continue;
+      lineDecoder.add(chunk);
+      if (finished) break;
+      if (!chunked) {
+        if (inHeader && inBody && contentLength >= 0) {
+          if ((contentRead + lineDecoder.bufferedBytes) >= contentLength) {
+            break;
+          }
+        }
       }
-      break;
     }
 
     try {

--- a/test/src/http/http_client_test.dart
+++ b/test/src/http/http_client_test.dart
@@ -41,10 +41,10 @@ void main() {
       expect(response.body, isEmpty);
     });
 
-    test('throws for non-identity transfer encoding', () async {
+    test('throws for unsupported transfer encoding', () async {
       final socket = _FakeSocket([
         'HTTP/1.1 200 OK\r\n',
-        'transfer-encoding: chunked\r\n',
+        'transfer-encoding: compress\r\n',
         'content-length: 0\r\n',
         '\r\n',
       ]);
@@ -64,6 +64,81 @@ void main() {
         SSHHttpClientResponse.from(socket),
         throwsA(isA<UnsupportedError>()),
       );
+    });
+  });
+
+  group('SSHHttpClientResponse chunked transfer encoding', () {
+    test('decodes a single-chunk body', () async {
+      final socket = _FakeSocket([
+        'HTTP/1.1 200 OK\r\n',
+        'transfer-encoding: chunked\r\n',
+        '\r\n',
+        '5\r\nhello\r\n0\r\n\r\n',
+      ]);
+
+      final response = await SSHHttpClientResponse.from(socket);
+
+      expect(response.statusCode, 200);
+      expect(response.body, 'hello');
+      expect(socket.closed, isTrue);
+    });
+
+    test('decodes multiple chunks into concatenated body', () async {
+      final socket = _FakeSocket([
+        'HTTP/1.1 200 OK\r\n',
+        'transfer-encoding: chunked\r\n',
+        '\r\n',
+        '5\r\nhello\r\n',
+        '1\r\n \r\n',
+        '6\r\nworld!\r\n0\r\n\r\n',
+      ]);
+
+      final response = await SSHHttpClientResponse.from(socket);
+
+      expect(response.body, 'hello world!');
+    });
+
+    test('ignores chunk extensions', () async {
+      final socket = _FakeSocket([
+        'HTTP/1.1 200 OK\r\n',
+        'transfer-encoding: chunked\r\n',
+        '\r\n',
+        '5;name=value\r\nhello\r\n0\r\n\r\n',
+      ]);
+
+      final response = await SSHHttpClientResponse.from(socket);
+
+      expect(response.body, 'hello');
+    });
+
+    test('parses trailer headers after last-chunk', () async {
+      final socket = _FakeSocket([
+        'HTTP/1.1 200 OK\r\n',
+        'transfer-encoding: chunked\r\n',
+        '\r\n',
+        '5\r\nhello\r\n0\r\n',
+        'x-trailer: yes\r\n',
+        '\r\n',
+      ]);
+
+      final response = await SSHHttpClientResponse.from(socket);
+
+      expect(response.body, 'hello');
+      expect(response.headers.value('x-trailer'), 'yes');
+    });
+
+    test('handles empty chunked body', () async {
+      final socket = _FakeSocket([
+        'HTTP/1.1 204 No Content\r\n',
+        'transfer-encoding: chunked\r\n',
+        '\r\n',
+        '0\r\n\r\n',
+      ]);
+
+      final response = await SSHHttpClientResponse.from(socket);
+
+      expect(response.statusCode, 204);
+      expect(response.body, isEmpty);
     });
   });
 


### PR DESCRIPTION
Implements RFC 7230 §4.1 chunked transfer-encoding decoding in SSHHttpClientResponse.from. Previously the client threw UnsupportedError('only identity transfer encoding is accepted') for any non-identity Transfer-Encoding, which broke interoperability with HTTP/1.1 servers that respond with Transfer-Encoding: chunked (common when the content length is not known ahead of time, e.g. dynamically generated content or streaming APIs tunneled over SSH).

Changes:
- Add a chunked-decode state machine (chunk size with optional extensions, chunk data, trailing CRLF, last-chunk, optional trailer headers).
- Decide body framing by inspecting Transfer-Encoding first, falling back to Content-Length for identity-encoded bodies.
- Accept both 'identity' and 'chunked' Transfer-Encoding values; reject anything else with a clearer UnsupportedError message.
- Validate header lines contain a colon separator before splitting.
- Add 5 test cases covering single chunk, multiple chunks, chunk extensions, trailer headers, and empty chunked bodies.
- Update the existing 'non-identity transfer encoding' test to use an actually unsupported encoding ('compress') since chunked is now supported.

Backport of ServerBox's forked `dartssh2`.