### PR TITLE
fix: prevent SSHTransport busy-loop on partial packets

### DIFF
--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -131,6 +131,9 @@ class SSHTransport {
   /// Guards asynchronous packet processing to preserve message order.
   var _isProcessingData = false;
 
+  /// Tracks whether new socket data was received since packet processing started.
+  var _hasNewData = false;
+
   /// Identification string sent by us without trailing \r\n. For example,
   /// "SSH-2.0-DartSSH_2.0".
   String get _localVersion => 'SSH-2.0-$version';
@@ -475,6 +478,7 @@ class SSHTransport {
   /// Callback triggered when new raw bytes are received from the socket.
   void _onSocketData(Uint8List data) {
     _buffer.add(data);
+    _hasNewData = true;
     _scheduleProcessData();
   }
 
@@ -496,6 +500,8 @@ class SSHTransport {
     }
 
     _isProcessingData = true;
+    final lengthBefore = _buffer.length;
+    _hasNewData = false;
 
     _processDataAsync().catchError((error, stackTrace) {
       if (error is SSHError) {
@@ -506,7 +512,9 @@ class SSHTransport {
     }).whenComplete(() {
       _isProcessingData = false;
       if (_buffer.isNotEmpty && !isClosed) {
-        _scheduleProcessData();
+        if (_hasNewData || _buffer.length < lengthBefore) {
+          _scheduleProcessData();
+        }
       }
     });
   }

--- a/test/src/ssh_transport_version_test.dart
+++ b/test/src/ssh_transport_version_test.dart
@@ -43,6 +43,27 @@ void main() {
 
       client.close();
     });
+
+    test('does not busy loop on partial packet after handshake', () async {
+      final socket = _FakeSSHSocket();
+      final client = SSHClient(
+        socket,
+        username: 'demo',
+      );
+
+      // Complete the version exchange.
+      socket.addIncoming('SSH-2.0-OpenSSH_3.6.1p2\r\n');
+      await _pumpUntil(() => client.remoteVersion != null);
+
+      // Send the first 4 bytes of a packet indicating a length of 100.
+      socket.addRawIncoming(Uint8List.fromList([0, 0, 0, 100]));
+
+      // Wait a moment. If there is a microtask busy loop, the delayed future
+      // will never run and the test will timeout.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      client.close();
+    });
   });
 }
 
@@ -72,6 +93,10 @@ class _FakeSSHSocket implements SSHSocket {
 
   void addIncoming(String data) {
     _inputController.add(Uint8List.fromList(latin1.encode(data)));
+  }
+
+  void addRawIncoming(Uint8List data) {
+    _inputController.add(data);
   }
 
   @override


### PR DESCRIPTION
Fixes #177.

`SSHTransport._scheduleProcessData` busy-loops at 100% CPU whenever a partial packet is left in the read buffer, permanently starving the event loop (and the socket reads that would complete the packet). On Flutter this pegs the platform thread and produces an "Input dispatching timed out" ANR / frozen UI.

### Root Cause
`_processPackets` returns as soon as `_consumePacket()` cannot form a complete packet. But `whenComplete` reschedules whenever `_buffer.isNotEmpty`, even when the pass consumed nothing. The reschedule runs as a microtask; microtasks have priority over I/O events, so the loop starves `_onSocketData` — the additional bytes needed to complete the packet are never delivered, and it spins forever.

### Fix
Only reschedule when the pass actually made progress (a packet was consumed) or new bytes arrived while processing (tracked by a new `_hasNewData` flag).

Also added a unit test to verify that the event loop is not starved when receiving a partial packet.