### PR TITLE
Add flush() method to SSHSocket, SSHClient, and SSHChannel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.22.2] - 2026-07-14
+- Added `flush()` to `SSHSocket`, `SSHClient`, and `SSHChannel` to allow force flushing of buffered outgoing data [#183]. Thanks [@vicajilau].
+
 ## [2.22.1] - 2026-07-13
 - Fixed a keepalive issue where overlapping pings could occur and caught errors during ping execution. Thanks [@vicajilau].
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## [2.22.1] - 2026-07-13
 - Fixed a keepalive issue where overlapping pings could occur and caught errors during ping execution. Thanks [@vicajilau].
 
-## [2.22.0] - 2026-07-13
+## [2.22.0] - 2026-07-03
 - Added optional `handshakeTimeout` and `authTimeout` to `SSHClient` to limit connection negotiation and user authentication times [#182]. Thanks [@GT-610].
 
 ## [2.21.1] - 2026-07-02

--- a/lib/src/socket/ssh_socket.dart
+++ b/lib/src/socket/ssh_socket.dart
@@ -28,4 +28,7 @@ abstract class SSHSocket {
   Future<void> close();
 
   void destroy();
+
+  /// Force flush any buffered outgoing data.
+  Future<void> flush() async {}
 }

--- a/lib/src/socket/ssh_socket_io.dart
+++ b/lib/src/socket/ssh_socket_io.dart
@@ -38,6 +38,11 @@ class _SSHNativeSocket implements SSHSocket {
   }
 
   @override
+  Future<void> flush() async {
+    await _socket.flush();
+  }
+
+  @override
   String toString() {
     final address = '${_socket.remoteAddress.host}:${_socket.remotePort}';
     return '_SSHNativeSocket($address)';

--- a/lib/src/ssh_channel.dart
+++ b/lib/src/ssh_channel.dart
@@ -31,6 +31,8 @@ class SSHChannelController {
 
   SSHChannel get channel => SSHChannel(this);
 
+  final Future<void> Function()? onFlush;
+
   SSHChannelController({
     required this.localId,
     required this.localMaximumPacketSize,
@@ -39,6 +41,7 @@ class SSHChannelController {
     required this.remoteInitialWindowSize,
     required this.remoteMaximumPacketSize,
     required this.sendMessage,
+    this.onFlush,
     this.printDebug,
   }) {
     if (remoteInitialWindowSize > 0) {
@@ -404,6 +407,10 @@ class SSHChannelController {
       _remoteWindow -= data.bytes.length;
     }
   });
+
+  Future<void> flush() async {
+    await onFlush?.call();
+  }
 }
 
 class SSHChannel {
@@ -433,6 +440,9 @@ class SSHChannel {
   void addData(Uint8List data, {int? type}) {
     sink.add(SSHChannelData(data, type: type));
   }
+
+  /// Force flush any buffered outgoing data on this channel to the socket.
+  Future<void> flush() => _controller.flush();
 
   void setRequestHandler(SSHChannelRequestHandler handler) {
     _controller._requestHandler = handler;

--- a/lib/src/ssh_client.dart
+++ b/lib/src/ssh_client.dart
@@ -701,6 +701,11 @@ class SSHClient {
     _transport.close();
   }
 
+  /// Force flush any buffered outgoing data to the socket.
+  Future<void> flush() async {
+    await _transport.flush();
+  }
+
   /// Close all channels that are currently open.
   void _closeChannels() {
     for (final channel in _channels.values) {
@@ -1376,6 +1381,7 @@ class SSHClient {
       remoteInitialWindowSize: remoteInitialWindowSize,
       remoteMaximumPacketSize: remoteMaximumPacketSize,
       sendMessage: _sendMessage,
+      onFlush: flush,
       printDebug: printDebug,
     );
 

--- a/lib/src/ssh_forward.dart
+++ b/lib/src/ssh_forward.dart
@@ -76,6 +76,13 @@ class SSHForwardChannel implements SSHSocket {
   void destroy() {
     _channel.destroy();
   }
+
+  /// Force flush any buffered outgoing data.
+  @override
+  Future<void> flush() async {
+    await Future.microtask(() {});
+    await _channel.flush();
+  }
 }
 
 class SSHX11Channel extends SSHForwardChannel {

--- a/lib/src/ssh_session.dart
+++ b/lib/src/ssh_session.dart
@@ -32,6 +32,9 @@ class SSHSession {
   /// be available on the [stdout] and [stderr] streams at this time.
   Future<void> get done => _channel.done;
 
+  /// The underlying SSH channel.
+  SSHChannel get channel => _channel;
+
   SSHSession(this._channel) {
     _channel.setRequestHandler(_handleRequest);
 
@@ -77,6 +80,12 @@ class SSHSession {
   /// method that calls [stdin.add].
   void write(Uint8List data) {
     stdin.add(data);
+  }
+
+  /// Force flush any buffered stdin data to the remote process.
+  Future<void> flush() async {
+    await Future.microtask(() {});
+    await _channel.flush();
   }
 
   /// Inform remote process of the current window size.

--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -464,6 +464,11 @@ class SSHTransport {
     socket.destroy();
   }
 
+  /// Force flush any buffered outgoing data to the socket.
+  Future<void> flush() async {
+    await socket.flush();
+  }
+
   /// Subscribes to the underlying socket stream to handle incoming data and status events.
   void _initSocket() {
     _socketSubscription = socket.stream.listen(

--- a/test/src/http/http_client_test.dart
+++ b/test/src/http/http_client_test.dart
@@ -300,4 +300,7 @@ class _FakeSocket implements SSHSocket {
     }
     unawaited(_sinkController.close());
   }
+
+  @override
+  Future<void> flush() async {}
 }

--- a/test/src/ssh_auth_abort_error_test.dart
+++ b/test/src/ssh_auth_abort_error_test.dart
@@ -75,6 +75,9 @@ class _FakeSSHSocket implements SSHSocket {
     }
     unawaited(_inputController.close());
   }
+
+  @override
+  Future<void> flush() async {}
 }
 
 class _RecordingSink implements StreamSink<List<int>> {

--- a/test/src/ssh_client_forward_dynamic_test.dart
+++ b/test/src/ssh_client_forward_dynamic_test.dart
@@ -64,6 +64,9 @@ class _FakeSSHSocket implements SSHSocket {
     }
     unawaited(_inputController.close());
   }
+
+  @override
+  Future<void> flush() async {}
 }
 
 class _NoopSink implements StreamSink<List<int>> {

--- a/test/src/ssh_client_ident_test.dart
+++ b/test/src/ssh_client_ident_test.dart
@@ -100,6 +100,9 @@ class _FakeSSHSocket implements SSHSocket {
     }
     unawaited(_inputController.close());
   }
+
+  @override
+  Future<void> flush() async {}
 }
 
 class _RecordingSink implements StreamSink<List<int>> {

--- a/test/src/ssh_client_run_with_result_test.dart
+++ b/test/src/ssh_client_run_with_result_test.dart
@@ -284,6 +284,9 @@ class _FakeSSHSocket implements SSHSocket {
     }
     unawaited(_inputController.close());
   }
+
+  @override
+  Future<void> flush() async {}
 }
 
 class _NoopSink implements StreamSink<List<int>> {

--- a/test/src/ssh_client_test.dart
+++ b/test/src/ssh_client_test.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:convert';
 
 import 'package:dartssh2/dartssh2.dart';
+import 'package:dartssh2/src/ssh_channel.dart';
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
@@ -261,6 +262,34 @@ void main() {
       }
       expect(result.exitSignal, isNull);
 
+      client.close();
+    });
+  });
+
+  group('SSHClient.flush', () {
+    test('can flush client, session, channel, and forward channel', () async {
+      final client = await getTestClient();
+      await client.authenticated;
+
+      await client.flush();
+
+      final session = await client.execute('echo flush_test');
+      await session.flush();
+
+      final controller = SSHChannelController(
+        localId: 1,
+        localMaximumPacketSize: 1024,
+        localInitialWindowSize: 1024,
+        remoteId: 2,
+        remoteMaximumPacketSize: 1024,
+        remoteInitialWindowSize: 1024,
+        sendMessage: (msg) {},
+        onFlush: () async {},
+      );
+      final forwardChannel = SSHForwardChannel(controller.channel);
+      await forwardChannel.flush();
+
+      await session.done;
       client.close();
     });
   });

--- a/test/src/ssh_client_timeout_test.dart
+++ b/test/src/ssh_client_timeout_test.dart
@@ -77,6 +77,9 @@ class _FakeSSHSocket implements SSHSocket {
     }
     unawaited(_inputController.close());
   }
+
+  @override
+  Future<void> flush() async {}
 }
 
 class _RecordingSink implements StreamSink<List<int>> {

--- a/test/src/ssh_flush_test.dart
+++ b/test/src/ssh_flush_test.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:mirrors';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:dartssh2/src/ssh_channel.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SSHSocket base class', () {
+    test('default flush implementation completes normally', () async {
+      final socket = _TestSSHSocket();
+      await expectLater(socket.flush(), completes);
+    });
+  });
+
+  group('SSHNativeSocket', () {
+    test('native socket flush works', () async {
+      final server = await ServerSocket.bind('127.0.0.1', 0);
+      final socket = await SSHSocket.connect('127.0.0.1', server.port);
+      await socket.flush();
+      await socket.close();
+      await server.close();
+    });
+  });
+
+  group('SSHTransport.flush', () {
+    test('delegates to socket.flush', () async {
+      final socket = _FakeSSHSocket();
+      final transport = SSHTransport(socket);
+      await transport.flush();
+      expect(socket.flushCount, 1);
+      transport.close();
+    });
+  });
+
+  group('SSHClient.flush and channel callback delegation', () {
+    test('delegates to transport and sets up onFlush', () async {
+      final socket = _FakeSSHSocket();
+      final client = SSHClient(socket, username: 'demo');
+      await client.flush();
+      expect(socket.flushCount, 1);
+
+      final clientLibrary = reflectClass(SSHClient).owner as LibraryMirror;
+      Symbol privateSymbol(String name) =>
+          MirrorSystem.getSymbol(name, clientLibrary);
+
+      // Invoke _acceptChannel using reflection to verify onFlush setup.
+      final channelController = reflect(client).invoke(
+        privateSymbol('_acceptChannel'),
+        [],
+        {
+          #localChannelId: 1,
+          #remoteChannelId: 2,
+          #remoteInitialWindowSize: 1024,
+          #remoteMaximumPacketSize: 1024,
+        },
+      ).reflectee as SSHChannelController;
+
+      expect(channelController.onFlush, isNotNull);
+      await channelController.flush();
+      expect(socket.flushCount, 2);
+
+      client.close();
+    });
+  });
+
+  group('SSHChannel.flush', () {
+    test('delegates to controller.flush', () async {
+      var flushed = false;
+      final controller = SSHChannelController(
+        localId: 1,
+        localMaximumPacketSize: 1024,
+        localInitialWindowSize: 1024,
+        remoteId: 2,
+        remoteMaximumPacketSize: 1024,
+        remoteInitialWindowSize: 1024,
+        sendMessage: (msg) {},
+        onFlush: () async {
+          flushed = true;
+        },
+      );
+      final channel = controller.channel;
+      await channel.flush();
+      expect(flushed, isTrue);
+    });
+  });
+
+  group('SSHSession.flush', () {
+    test('exposes channel and delegates flush', () async {
+      var flushed = false;
+      final controller = SSHChannelController(
+        localId: 1,
+        localMaximumPacketSize: 1024,
+        localInitialWindowSize: 1024,
+        remoteId: 2,
+        remoteMaximumPacketSize: 1024,
+        remoteInitialWindowSize: 1024,
+        sendMessage: (msg) {},
+        onFlush: () async {
+          flushed = true;
+        },
+      );
+      final channel = controller.channel;
+      final session = SSHSession(channel);
+      expect(session.channel, channel);
+
+      await session.flush();
+      expect(flushed, isTrue);
+    });
+  });
+
+  group('SSHForwardChannel.flush', () {
+    test('delegates to channel.flush', () async {
+      var flushed = false;
+      final controller = SSHChannelController(
+        localId: 1,
+        localMaximumPacketSize: 1024,
+        localInitialWindowSize: 1024,
+        remoteId: 2,
+        remoteMaximumPacketSize: 1024,
+        remoteInitialWindowSize: 1024,
+        sendMessage: (msg) {},
+        onFlush: () async {
+          flushed = true;
+        },
+      );
+      final forwardChannel = SSHForwardChannel(controller.channel);
+      await forwardChannel.flush();
+      expect(flushed, isTrue);
+    });
+  });
+}
+
+class _TestSSHSocket extends SSHSocket {
+  @override
+  Stream<Uint8List> get stream => throw UnimplementedError();
+
+  @override
+  StreamSink<List<int>> get sink => throw UnimplementedError();
+
+  @override
+  Future<void> get done => throw UnimplementedError();
+
+  @override
+  Future<void> close() => throw UnimplementedError();
+
+  @override
+  void destroy() => throw UnimplementedError();
+}
+
+class _FakeSSHSocket implements SSHSocket {
+  int flushCount = 0;
+  final _streamController = StreamController<Uint8List>();
+  final _sinkController = StreamController<List<int>>();
+
+  @override
+  Stream<Uint8List> get stream => _streamController.stream;
+
+  @override
+  StreamSink<List<int>> get sink => _sinkController.sink;
+
+  @override
+  Future<void> get done => _streamController.done;
+
+  @override
+  Future<void> close() async {
+    await _streamController.close();
+    await _sinkController.close();
+  }
+
+  @override
+  void destroy() {}
+
+  @override
+  Future<void> flush() async {
+    flushCount++;
+  }
+}

--- a/test/src/ssh_transport_aead_test.dart
+++ b/test/src/ssh_transport_aead_test.dart
@@ -548,6 +548,9 @@ class _CaptureSSHSocket implements SSHSocket {
     }
     unawaited(_inputController.close());
   }
+
+  @override
+  Future<void> flush() async {}
 }
 
 class _CaptureSink implements StreamSink<List<int>> {

--- a/test/src/ssh_transport_version_test.dart
+++ b/test/src/ssh_transport_version_test.dart
@@ -133,6 +133,9 @@ class _FakeSSHSocket implements SSHSocket {
     }
     unawaited(_inputController.close());
   }
+
+  @override
+  Future<void> flush() async {}
 }
 
 class _RecordingSink implements StreamSink<List<int>> {


### PR DESCRIPTION
This pull request introduces a new `flush()` method to the `SSHSocket`, `SSHClient`, and `SSHChannel` classes, allowing users to force the flushing of any buffered outgoing data. The implementation is propagated across the main library code, channel controllers, and test fakes to ensure consistent behavior and testability.

### New flush functionality

* Added a `flush()` method to the `SSHSocket` abstract class and implemented it in all concrete socket classes, including `_SSHNativeSocket` and `SSHForwardChannel`, to force flushing of buffered outgoing data.
* Implemented `flush()` in `SSHTransport` to call the underlying socket's `flush()` method, ensuring transport-level flushing.
* Added a `flush()` method to `SSHClient` that delegates to the transport layer, and passed this method into `SSHChannelController` for channel-level flushing.
* Exposed a `flush()` method on `SSHChannel` that delegates to its controller, and updated `SSHChannelController` to support an optional `onFlush` callback and provide a `flush()` method.

### Test support

* Updated all relevant test fake socket classes to implement a no-op `flush()` method, ensuring compatibility with the new interface in tests.

### Documentation

* Updated `CHANGELOG.md` to document the addition of the `flush()` method to the public API.