### PR TITLE
fix(sftp): close the underlying channel in SftpClient.close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.22.3] - 2026-07-20
+- Fixed an SSH channel leak in `SftpClient.close()` by closing the underlying SSH channel and returning `Future<void>` to allow awaiting channel teardown [#186]. Thanks [@keinstn].
+
 ## [2.22.2] - 2026-07-15
 - Added `flush()` to `SSHSocket`, `SSHClient`, and `SSHChannel` to allow force flushing of buffered outgoing data [#183]. Thanks [@vicajilau].
 

--- a/lib/src/sftp/sftp_client.dart
+++ b/lib/src/sftp/sftp_client.dart
@@ -228,12 +228,20 @@ class SftpClient {
   }
 
   /// Close the sftp session.
-  void close() {
+  ///
+  /// This also closes the underlying SSH channel that the sftp subsystem runs
+  /// on. Without this the channel is leaked: every [SSHClient.sftp] call opens
+  /// a fresh session channel, so an application that opens an sftp session per
+  /// operation would accumulate open channels on the connection until the
+  /// server refuses further `CHANNEL_OPEN`s.
+  Future<void> close() async {
+    if (_done.isCompleted) return;
     for (var waiter in _replyWaiters.values) {
       waiter.completeError(SftpAbortError("Connection closed"));
     }
     _replyWaiters.clear();
     _done.complete();
+    await _channel.close();
   }
 
   void _closeError(Object error, [StackTrace? stackTrace]) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartssh2
-version: 2.22.2
+version: 2.22.3
 description: SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as easy to use.
 homepage: https://github.com/TerminalStudio/dartssh2
 

--- a/test/src/sftp/sftp_client_protocol_test.dart
+++ b/test/src/sftp/sftp_client_protocol_test.dart
@@ -93,9 +93,24 @@ void main() {
       final openFuture = harness.client.open('/tmp/f');
       await harness.nextOutgoingPacket();
 
-      harness.client.close();
+      unawaited(harness.client.close());
 
       await expectLater(openFuture, throwsA(isA<SftpAbortError>()));
+      harness.dispose();
+    });
+
+    test('close closes the underlying channel', () async {
+      final harness = _SftpHarness();
+      await harness.nextOutgoingPacket();
+      harness.sendResponsePacket(SftpVersionPacket(3));
+      await harness.client.handshake;
+
+      final closeFuture = harness.client.close();
+      // The server acks the channel close, letting the teardown complete.
+      harness.closeRemote();
+      await closeFuture;
+
+      await expectLater(harness.channelDone, completes);
       harness.dispose();
     });
 
@@ -546,6 +561,14 @@ class _SftpHarness {
 
   Future<Uint8List> nextOutgoingPacket() => _outgoing.stream.first;
 
+  Future<void> get channelDone => _controller.channel.done;
+
+  void closeRemote() {
+    _controller.handleMessage(
+      SSH_Message_Channel_Close(recipientChannel: _controller.localId),
+    );
+  }
+
   void sendResponsePacket(SftpPacket packet) {
     final payload = packet.encode();
     final writer = SSHMessageWriter();
@@ -564,11 +587,7 @@ class _SftpHarness {
     if (_disposed) return;
     _disposed = true;
 
-    try {
-      client.close();
-    } catch (_) {
-      // SftpClient.close is not idempotent when already completed with error.
-    }
+    unawaited(client.close());
     _controller.destroy();
     _outgoing.close();
   }


### PR DESCRIPTION
## Problem

`SftpClient.close()` completes its internal futures but never closes the SSH channel the sftp subsystem runs on. Since `SSHClient.sftp()` opens a **fresh** session channel on every call, an application that opens an sftp session per operation leaks one open channel each time. These accumulate on the connection until the server refuses further `CHANNEL_OPEN`s — e.g. `CHANNEL_OPEN_FAILURE` / a per-connection session limit (observed against a Tailscale SSH server as `SSHChannelOpenError(2: open failed)`).

The `execute`/session path is unaffected because it awaits the full close handshake; only sftp sessions leaked.

## Fix

- Close the underlying channel when the sftp session is closed.
- Make `close()` `async` (returns `Future<void>`) so callers can await the channel teardown. Source-compatible: existing `sftp.close();` call sites keep compiling (the returned future is simply discarded).
- Guard against double-close so `close()` is idempotent.

## Testing

- New unit test in `test/src/sftp/sftp_client_protocol_test.dart` (`close closes the underlying channel`) verifying the channel is torn down.
- `dart format`, `dart analyze --fatal-infos`, unit tests, and the sftp integration tests (against `test.rebex.net`) all pass locally.

Happy to add a CHANGELOG entry if you'd prefer contributors to include one.