### PR TITLE
Advertise the RFC 8731 kex name curve25519-sha256

### DIFF
--- a/lib/src/algorithm/ssh_kex_type.dart
+++ b/lib/src/algorithm/ssh_kex_type.dart
@@ -7,6 +7,15 @@ class SSHKexType extends SSHAlgorithm {
     digestFactory: digestSha256,
   );
 
+  /// RFC 8731 name for the same algorithm as [x25519]. Servers hardened to a
+  /// single kex commonly offer only this spelling, and OpenSSH matches names
+  /// literally — without it the handshake dies with "no matching key exchange
+  /// method found".
+  static const x25519Rfc = SSHKexType._(
+    name: 'curve25519-sha256',
+    digestFactory: digestSha256,
+  );
+
   static const nistp256 = SSHKexType._(
     name: 'ecdh-sha2-nistp256',
     digestFactory: digestSha256,

--- a/lib/src/ssh_algorithm.dart
+++ b/lib/src/ssh_algorithm.dart
@@ -46,6 +46,7 @@ class SSHAlgorithms {
   const SSHAlgorithms({
     this.kex = const [
       SSHKexType.x25519,
+      SSHKexType.x25519Rfc,
       SSHKexType.nistp521,
       SSHKexType.nistp384,
       SSHKexType.nistp256,

--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -1196,6 +1196,7 @@ class SSHTransport {
 
     switch (_kexType) {
       case SSHKexType.x25519:
+      case SSHKexType.x25519Rfc:
         _kex = await SSHKexX25519.createAsync();
         break;
       case SSHKexType.nistp256:

--- a/test/src/algorithm/ssh_cipher_type_test.dart
+++ b/test/src/algorithm/ssh_cipher_type_test.dart
@@ -106,6 +106,7 @@ void main() {
         algorithms.kex,
         equals([
           SSHKexType.x25519,
+          SSHKexType.x25519Rfc,
           SSHKexType.nistp521,
           SSHKexType.nistp384,
           SSHKexType.nistp256,


### PR DESCRIPTION
### Problem

`curve25519-sha256@libssh.org` and `curve25519-sha256` are two names for the **same** key exchange — the latter is the name RFC 8731 standardised. dartssh2 only ever advertises the libssh.org spelling.

OpenSSH matches algorithm names literally, so a server hardened down to a single kex:

```
KexAlgorithms curve25519-sha256
```

shares no name with us and the handshake dies with `Bad state: No matching key exchange algorithm`, even though both sides implement exactly the same X25519 exchange. That configuration is a common hardening recipe, so this is not an exotic server.

Reproduced against OpenSSH 9.9 offering `kexAlgorithms: [curve25519-sha256, ext-info-s, kex-strict-s-v00@openssh.com]`.

### Change

- `SSHKexType.x25519Rfc` — same `digestSha256`, RFC name.
- Offered right after `x25519` in the default `SSHAlgorithms.kex` list.
- One extra `case` in the transport switch, falling through to the same `SSHKexX25519()`.

No wire-format change: identical exchange, identical digest, only the negotiated name differs. The default-algorithm-list assertion in `test/src/algorithm/ssh_cipher_type_test.dart` is updated for the new entry; `dart test` passes (292 tests).

Verified end to end: with this patch (plus `aes*-gcm@openssh.com` in the cipher list) an SFTP session against the hardened server above connects and lists directories; unpatched it fails at KEXINIT.
