### PR TITLE
fix: export ssh_userauth.dart in public API (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.22.5] - 2026-07-30
+- Exported `src/ssh_userauth.dart` in `lib/dartssh2.dart` to expose `SSHUserInfoRequest`, `SSHUserInfoPrompt`, `SSHAuthMethod`, and `SSHChangePasswordResponse` [#188]. Thanks [@vicajilau].
+
 ## [2.22.4] - 2026-07-27
 - Advertised standard RFC 8731 key exchange name `curve25519-sha256` alongside legacy `curve25519-sha256@libssh.org` [#187]. Thanks [@nickn17].
 
@@ -279,6 +282,7 @@
 [#175]: https://github.com/TerminalStudio/dartssh2/pull/175
 [#176]: https://github.com/TerminalStudio/dartssh2/pull/176
 [#1]: https://github.com/TerminalStudio/dartssh/pull/1/files
+[#188]: https://github.com/TerminalStudio/dartssh2/issues/188
 
 [@linhanyu]: https://github.com/linhanyu
 [@Migarl]: https://github.com/Migarl

--- a/lib/dartssh2.dart
+++ b/lib/dartssh2.dart
@@ -8,6 +8,7 @@ export 'src/ssh_pem.dart';
 export 'src/ssh_session.dart';
 export 'src/ssh_signal.dart';
 export 'src/ssh_transport.dart';
+export 'src/ssh_userauth.dart';
 
 export 'src/socket/ssh_socket.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartssh2
-version: 2.22.4
+version: 2.22.5
 description: SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as easy to use.
 homepage: https://github.com/TerminalStudio/dartssh2
 

--- a/test/src/ssh_userauth_export_test.dart
+++ b/test/src/ssh_userauth_export_test.dart
@@ -2,7 +2,9 @@ import 'package:dartssh2/dartssh2.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('SSHUserInfoRequest and related userauth classes are exported by dartssh2.dart', () {
+  test(
+      'SSHUserInfoRequest and related userauth classes are exported by dartssh2.dart',
+      () {
     final prompt = SSHUserInfoPrompt('Password:', false);
     expect(prompt.promptText, equals('Password:'));
     expect(prompt.echo, isFalse);
@@ -17,6 +19,7 @@ void main() {
     expect(changePasswordResponse.oldPassword, equals('old'));
     expect(changePasswordResponse.newPassword, equals('new'));
 
-    expect(SSHAuthMethod.keyboardInteractive.name, equals('keyboard-interactive'));
+    expect(
+        SSHAuthMethod.keyboardInteractive.name, equals('keyboard-interactive'));
   });
 }

--- a/test/src/ssh_userauth_export_test.dart
+++ b/test/src/ssh_userauth_export_test.dart
@@ -1,0 +1,22 @@
+import 'package:dartssh2/dartssh2.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('SSHUserInfoRequest and related userauth classes are exported by dartssh2.dart', () {
+    final prompt = SSHUserInfoPrompt('Password:', false);
+    expect(prompt.promptText, equals('Password:'));
+    expect(prompt.echo, isFalse);
+
+    final request = SSHUserInfoRequest('Title', 'Instruction', [prompt]);
+    expect(request.name, equals('Title'));
+    expect(request.instruction, equals('Instruction'));
+    expect(request.prompts.length, equals(1));
+    expect(request.prompts.first.promptText, equals('Password:'));
+
+    final changePasswordResponse = SSHChangePasswordResponse('old', 'new');
+    expect(changePasswordResponse.oldPassword, equals('old'));
+    expect(changePasswordResponse.newPassword, equals('new'));
+
+    expect(SSHAuthMethod.keyboardInteractive.name, equals('keyboard-interactive'));
+  });
+}


### PR DESCRIPTION
Closes #188. 

This pull request updates the package to version 2.22.5 and improves the public API by exporting user authentication types from `dartssh2.dart`. It also adds a test to ensure these types are accessible, and updates the changelog accordingly.

**Public API changes:**

* Exported `src/ssh_userauth.dart` in `lib/dartssh2.dart`, making `SSHUserInfoRequest`, `SSHUserInfoPrompt`, `SSHAuthMethod`, and `SSHChangePasswordResponse` available to library users.

**Testing:**

* Added `test/src/ssh_userauth_export_test.dart` to verify that user authentication types are correctly exported and usable from the main library entrypoint.

**Documentation:**

* Updated `CHANGELOG.md` to document the export of user authentication types and reference issue.

**Versioning:**

* Bumped package version to 2.22.5 in `pubspec.yaml`.