### PR TITLE
Use a cryptographically secure random source

### DIFF
--- a/lib/src/utils/list.dart
+++ b/lib/src/utils/list.dart
@@ -2,11 +2,12 @@ import 'dart:math';
 
 import 'dart:typed_data';
 
+final _secureRandom = Random.secure();
+
 Uint8List randomBytes(int length) {
-  final random = Random();
   final bytes = Uint8List(length);
   for (var i = 0; i < length; i++) {
-    bytes[i] = random.nextInt(255);
+    bytes[i] = _secureRandom.nextInt(256);
   }
   return bytes;
 }

--- a/test/src/utils/list_test.dart
+++ b/test/src/utils/list_test.dart
@@ -1,0 +1,16 @@
+import 'package:dartssh2/src/utils/list.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('randomBytes', () {
+    test('returns the requested number of bytes', () {
+      expect(randomBytes(0), isEmpty);
+      expect(randomBytes(32), hasLength(32));
+    });
+
+    test('uses the full byte range', () {
+      final bytes = randomBytes(65536);
+      expect(bytes, contains(255));
+    });
+  });
+}


### PR DESCRIPTION
Backport of ServerBox's fork, but with some tweaks to align with OpenSSH 10.15 behavior.

- use a persistent `Random.secure()` instance for SSH protocol randomness
- generate values across the complete byte range, including `0xff`
- add regression tests for output length and full-range generation

## Security impact

`randomBytes()` supplies randomness for SSH key-exchange cookies, ephemeral key-exchange private values, OpenSSH private-key encryption seeds, and packet padding. Dart's default `Random()` is not suitable for cryptographic use, while OpenSSH uses the operating system-backed `arc4random_buf()` for the corresponding operations.

The previous `nextInt(255)` call also excluded the valid byte value `0xff`. This change uses `nextInt(256)` so every byte value can be emitted.