### PR TITLE
Fix X11 screen number encoding

### DIFF
--- a/lib/src/message/msg_channel.dart
+++ b/lib/src/message/msg_channel.dart
@@ -608,7 +608,7 @@ class SSH_Message_Channel_Request implements SSHMessage {
   final bool? singleConnection;
   final String? x11AuthenticationProtocol;
   final String? x11AuthenticationCookie;
-  final String? x11ScreenNumber;
+  final int? x11ScreenNumber;
 
   /// "env" request specific data
   final String? variableName;
@@ -689,7 +689,7 @@ class SSH_Message_Channel_Request implements SSHMessage {
     bool singleConnection = false,
     required String x11AuthenticationProtocol,
     required String x11AuthenticationCookie,
-    required String x11ScreenNumber,
+    required int x11ScreenNumber,
   }) {
     return SSH_Message_Channel_Request(
       recipientChannel: recipientChannel,
@@ -851,7 +851,7 @@ class SSH_Message_Channel_Request implements SSHMessage {
         final singleConnection = reader.readBool();
         final x11AuthenticationProtocol = reader.readUtf8();
         final x11AuthenticationCookie = reader.readUtf8();
-        final x11ScreenNumber = reader.readUtf8();
+        final x11ScreenNumber = reader.readUint32();
         return SSH_Message_Channel_Request(
           recipientChannel: recipientChannel,
           requestType: requestType,
@@ -955,7 +955,7 @@ class SSH_Message_Channel_Request implements SSHMessage {
         writer.writeBool(singleConnection!);
         writer.writeUtf8(x11AuthenticationProtocol!);
         writer.writeUtf8(x11AuthenticationCookie!);
-        writer.writeUtf8(x11ScreenNumber!);
+        writer.writeUint32(x11ScreenNumber!);
         break;
       case 'env':
         writer.writeUtf8(variableName!);

--- a/lib/src/ssh_channel.dart
+++ b/lib/src/ssh_channel.dart
@@ -136,7 +136,7 @@ class SSHChannelController {
         singleConnection: singleConnection,
         x11AuthenticationProtocol: authenticationProtocol,
         x11AuthenticationCookie: authenticationCookie,
-        x11ScreenNumber: screenNumber.toString(),
+        x11ScreenNumber: screenNumber,
       ),
     );
     return await _requestReplyQueue.next;

--- a/test/src/message/msg_channel_test.dart
+++ b/test/src/message/msg_channel_test.dart
@@ -197,10 +197,13 @@ void main() {
         singleConnection: true,
         x11AuthenticationProtocol: 'MIT-MAGIC-COOKIE-1',
         x11AuthenticationCookie: 'deadbeef',
-        x11ScreenNumber: '0',
+        x11ScreenNumber: 0x01020304,
       );
 
-      final decoded = SSH_Message_Channel_Request.decode(message.encode());
+      final encoded = message.encode();
+      expect(encoded.sublist(encoded.length - 4), [1, 2, 3, 4]);
+
+      final decoded = SSH_Message_Channel_Request.decode(encoded);
 
       expect(decoded.requestType, SSHChannelRequestType.x11);
       expect(decoded.recipientChannel, 5);
@@ -208,7 +211,7 @@ void main() {
       expect(decoded.singleConnection, isTrue);
       expect(decoded.x11AuthenticationProtocol, 'MIT-MAGIC-COOKIE-1');
       expect(decoded.x11AuthenticationCookie, 'deadbeef');
-      expect(decoded.x11ScreenNumber, '0');
+      expect(decoded.x11ScreenNumber, 0x01020304);
     });
 
     test('auth-agent request encode/decode roundtrip', () {


### PR DESCRIPTION
RFC 4254 section 6.3 defines the X11 screen number field as `uint32`. OpenSSH likewise serializes it with `sshpkt_put_u32()` and parses it with `sshpkt_get_u32()`. Encoding the value as a string adds an incorrect length prefix and ASCII representation, making the request incompatible with conforming SSH servers.

The public `sendX11Req` API already accepts an `int`, so this change fixes the message representation without changing that API.