### PR TITLE
Fix SSHChannel.remoteChannelId

### DIFF
--- a/lib/src/ssh_channel.dart
+++ b/lib/src/ssh_channel.dart
@@ -418,7 +418,7 @@ class SSHChannel {
   SSHChannelId get channelId => _controller.localId;
 
   /// The channel id on the remote side.
-  SSHChannelId get remoteChannelId => _controller.localId;
+  SSHChannelId get remoteChannelId => _controller.remoteId;
 
   /// The maximum packet size that the remote side can receive.
   int get maximumPacketSize => _controller.remoteMaximumPacketSize;

--- a/test/src/ssh_channel_test.dart
+++ b/test/src/ssh_channel_test.dart
@@ -1,0 +1,21 @@
+import 'package:dartssh2/src/ssh_channel.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('exposes distinct local and remote channel IDs', () {
+    final controller = SSHChannelController(
+      localId: 1,
+      localMaximumPacketSize: 1024,
+      localInitialWindowSize: 1024,
+      remoteId: 42,
+      remoteMaximumPacketSize: 1024,
+      remoteInitialWindowSize: 0,
+      sendMessage: (_) {},
+    );
+
+    final channel = controller.channel;
+
+    expect(channel.channelId, 1);
+    expect(channel.remoteChannelId, 42);
+  });
+}


### PR DESCRIPTION
Return the peer-assigned channel ID from `SSHChannel.remoteChannelId` according to RFC 4254.