### PR TITLE
fix: propagate stderr stream errors in runWithResult and release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.0.1] - 2026-08-16
+- Fixed X11 forwarding by encoding and decoding the `x11-req` screen number as a `uint32` instead of a string, as required by RFC 4254 §6.3 [#194]. Thanks [@GT-610].
+- Fixed `SSHChannel.remoteChannelId` returning the local channel id instead of the id assigned by the peer [#196]. Thanks [@GT-610].
+- Fixed `SSHClient.run()` and `SSHClient.runWithResult()` hanging forever when the stdout stream emitted an error, by routing stdout errors to the stdout completer [#195]. Thanks [@GT-610].
+- Fixed `SSHClient.run()` and `SSHClient.runWithResult()` raising an uncaught error, instead of throwing to the caller, when the stderr stream emitted an error while stdout was still open. Both streams are now awaited together, and the session is closed on failure so the SSH channel is no longer leaked [#197].
+- Switched SSH protocol randomness to a `Random.secure()` source and widened byte generation to the full `0x00`-`0xff` range, covering key exchange cookies, ephemeral key exchange private values, and OpenSSH private key encryption seeds [#193]. Thanks [@GT-610].
+
 ## [3.0.0] - 2026-08-16
 - **BREAKING**: Changed `SSHClient.identities` getter type from `List<SSHKeyPair>?` to `List<SSHIdentity>?` to support asynchronous external signers (OS agents, hardware tokens, smart cards, Secure Enclave, Android Keystore, and custom signers) [#190]. Constructor invocations passing `List<SSHKeyPair>` remain 100% source-compatible.
 - **BREAKING**: Changed `SSHClient.close()` return type from `void` to `Future<void>` to allow awaiting complete socket and channel teardown.
@@ -290,6 +297,12 @@
 [#176]: https://github.com/TerminalStudio/dartssh2/pull/176
 [#1]: https://github.com/TerminalStudio/dartssh/pull/1/files
 [#188]: https://github.com/TerminalStudio/dartssh2/issues/188
+[#190]: https://github.com/TerminalStudio/dartssh2/issues/190
+[#193]: https://github.com/TerminalStudio/dartssh2/pull/193
+[#194]: https://github.com/TerminalStudio/dartssh2/pull/194
+[#195]: https://github.com/TerminalStudio/dartssh2/pull/195
+[#196]: https://github.com/TerminalStudio/dartssh2/pull/196
+[#197]: https://github.com/TerminalStudio/dartssh2/pull/197
 
 [@linhanyu]: https://github.com/linhanyu
 [@Migarl]: https://github.com/Migarl

--- a/lib/src/ssh_client.dart
+++ b/lib/src/ssh_client.dart
@@ -633,6 +633,9 @@ class SSHClient {
 
   /// Execute [command] on the remote side non-interactively and return
   /// output together with exit metadata.
+  ///
+  /// If the standard output or standard error stream emits an error, the
+  /// session is closed and that error is rethrown to the caller.
   Future<SSHRunResult> runWithResult(
     String command, {
     bool runInPty = false,
@@ -652,7 +655,7 @@ class SSHClient {
     final stdoutDone = Completer<void>();
     final stderrDone = Completer<void>();
 
-    session.stdout.listen(
+    final stdoutSubscription = session.stdout.listen(
       stdout
           ? (data) {
               outputBuilder.add(data);
@@ -664,7 +667,7 @@ class SSHClient {
       cancelOnError: true,
     );
 
-    session.stderr.listen(
+    final stderrSubscription = session.stderr.listen(
       stderr
           ? (data) {
               outputBuilder.add(data);
@@ -676,9 +679,21 @@ class SSHClient {
       cancelOnError: true,
     );
 
-    await stdoutDone.future;
-    await stderrDone.future;
-    await session.done;
+    // Both futures must be awaited together. Awaiting them one after the other
+    // would leave the second one without an error handler until the first one
+    // completes, turning an error on that stream into an uncaught error.
+    try {
+      await Future.wait(
+        [stdoutDone.future, stderrDone.future],
+        eagerError: true,
+      );
+      await session.done;
+    } catch (_) {
+      await stdoutSubscription.cancel();
+      await stderrSubscription.cancel();
+      session.close();
+      rethrow;
+    }
 
     return SSHRunResult(
       output: outputBuilder.takeBytes(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartssh2
-version: 3.0.0
+version: 3.0.1
 description: SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as easy to use.
 homepage: https://github.com/TerminalStudio/dartssh2
 

--- a/test/src/ssh_client_run_with_result_test.dart
+++ b/test/src/ssh_client_run_with_result_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:dartssh2/dartssh2.dart';
 import 'package:dartssh2/src/message/msg_channel.dart';
 import 'package:dartssh2/src/ssh_channel.dart';
+import 'package:dartssh2/src/ssh_message.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -164,6 +165,40 @@ void main() {
       client.close();
     });
 
+    test('propagates stderr stream errors while stdout is open', () async {
+      final error = StateError('stderr failed');
+      final harness = _SessionHarness(stderrError: error);
+      final client = _TestSSHClient(() async => harness.session);
+
+      await expectLater(
+        client.runWithResult('cmd').timeout(const Duration(seconds: 1)),
+        throwsA(same(error)),
+      );
+
+      harness.dispose();
+      client.close();
+    });
+
+    test('tears down the session when a stream fails', () async {
+      final error = StateError('stdout failed');
+      final harness = _SessionHarness(stdoutError: error);
+      final client = _TestSSHClient(() async => harness.session);
+
+      await expectLater(
+        client.runWithResult('cmd').timeout(const Duration(seconds: 1)),
+        throwsA(same(error)),
+      );
+
+      expect(
+        harness.sentMessages.whereType<SSH_Message_Channel_EOF>(),
+        isNotEmpty,
+        reason: 'the session must be torn down instead of leaking the channel',
+      );
+
+      harness.dispose();
+      client.close();
+    });
+
     test('run() returns combined output bytes', () async {
       final harness = _SessionHarness();
       final client = _TestSSHClient(() async {
@@ -207,7 +242,7 @@ class _TestSSHClient extends SSHClient {
 }
 
 class _SessionHarness {
-  _SessionHarness({Object? stdoutError}) {
+  _SessionHarness({Object? stdoutError, Object? stderrError}) {
     _controller = SSHChannelController(
       localId: 1,
       localMaximumPacketSize: 1024 * 1024,
@@ -215,12 +250,18 @@ class _SessionHarness {
       remoteId: 2,
       remoteMaximumPacketSize: 1024 * 1024,
       remoteInitialWindowSize: 1024 * 1024,
-      sendMessage: (_) {},
+      sendMessage: sentMessages.add,
     );
-    session = stdoutError == null
+    session = stdoutError == null && stderrError == null
         ? SSHSession(_controller.channel)
-        : _StdoutErrorSSHSession(_controller.channel, stdoutError);
+        : _FailingStreamSSHSession(
+            _controller.channel,
+            stdoutError: stdoutError,
+            stderrError: stderrError,
+          );
   }
+
+  final sentMessages = <SSHMessage>[];
 
   late final SSHChannelController _controller;
   late final SSHSession session;
@@ -275,14 +316,28 @@ class _SessionHarness {
   }
 }
 
-class _StdoutErrorSSHSession extends SSHSession {
-  _StdoutErrorSSHSession(super.channel, Object error)
-      : _stdout = Stream<Uint8List>.error(error);
+class _FailingStreamSSHSession extends SSHSession {
+  _FailingStreamSSHSession(
+    super.channel, {
+    Object? stdoutError,
+    Object? stderrError,
+  })  : _stdoutError = stdoutError,
+        _stderrError = stderrError;
 
-  final Stream<Uint8List> _stdout;
+  final Object? _stdoutError;
+  final Object? _stderrError;
 
   @override
-  Stream<Uint8List> get stdout => _stdout;
+  Stream<Uint8List> get stdout {
+    final error = _stdoutError;
+    return error == null ? super.stdout : Stream<Uint8List>.error(error);
+  }
+
+  @override
+  Stream<Uint8List> get stderr {
+    final error = _stderrError;
+    return error == null ? super.stderr : Stream<Uint8List>.error(error);
+  }
 }
 
 class _FakeSSHSocket implements SSHSocket {


### PR DESCRIPTION
Follow up to #195, plus the 3.0.1 release notes.

## The remaining bug

#195 fixed stdout errors being routed to the stderr completer. The mirror case was still broken: `runWithResult()` awaits `stdoutDone.future` first and only then `stderrDone.future`, so an error on **stderr** while stdout is still open completes a future that has no listener attached yet.

In Dart that does not surface as a catchable exception, it escapes to the zone as an uncaught error and kills the isolate. On top of that the call never returns, because `stdoutDone` is still pending. Minimal repro:

```dart
final a = Completer<void>();
final b = Completer<void>();
scheduleMicrotask(() => b.completeError(StateError('stderr failed')));
Timer(const Duration(milliseconds: 50), () => a.complete());
await a.future;
try { await b.future; } catch (e) { print('caught: $e'); }
```

This prints `Unhandled exception: Bad state: stderr failed` and the `catch` never runs.

A second problem: when `runWithResult()` throws, the session was never closed, so the SSH channel leaked.

## The fix

Both completers are now awaited together with `Future.wait(..., eagerError: true)`. That attaches an error handler to both futures immediately, completes on the first error, and absorbs a late second error instead of letting it escape. On failure the subscriptions are cancelled and the session is closed.

The happy path is unchanged: both futures complete normally and this behaves exactly like the two sequential awaits it replaces. The `cancelOnError: true` introduced in #195 is kept.

`SSHChannelController.close()` is safe to call here, it returns early on `_done.isCompleted` and `_sendCloseIfNeeded()` is guarded by `_hasSentClose`, so it is idempotent.

## Tests

Two regression tests, both of which fail on `master` before this change:

- `propagates stderr stream errors while stdout is open` fails with `TimeoutException after 0:00:01` instead of throwing.
- `tears down the session when a stream fails` fails because no `SSH_Message_Channel_EOF` is ever sent.

`_StdoutErrorSSHSession` from #195 is generalized into `_FailingStreamSSHSession` so both streams can be exercised, and the harness now records the messages sent on the channel.

Full suite: 338 tests passing, `dart analyze` clean.

## Release

Bumps to 3.0.1 and collects the notes for #193, #194, #195 and #196. Also adds the `[#190]` link definition, which the 3.0.0 notes referenced without defining, so it was rendering as literal text on pub.dev.
