### PR TITLE
fix: derive the OpenSSH PEM check int from the secure random source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fixed `SSHClient.run()` and `SSHClient.runWithResult()` hanging forever when the stdout stream emitted an error, by routing stdout errors to the stdout completer [#195]. Thanks [@GT-610].
 - Fixed `SSHClient.run()` and `SSHClient.runWithResult()` raising an uncaught error, instead of throwing to the caller, when the stderr stream emitted an error while stdout was still open. Both streams are now awaited together, and the session is closed on failure so the SSH channel is no longer leaked [#197].
 - Switched SSH protocol randomness to a `Random.secure()` source and widened byte generation to the full `0x00`-`0xff` range, covering key exchange cookies, ephemeral key exchange private values, and OpenSSH private key encryption seeds [#193]. Thanks [@GT-610].
-- Switched the check int of OpenSSH private keys written by `SSHKeyPair.toPem()` to the same secure random source, removing the last insecure `Random()` usage in the library.
+- Switched the check int of OpenSSH private keys written by `SSHKeyPair.toPem()` to the same secure random source, removing the last insecure `Random()` usage in the library [#198].
 
 ## [3.0.0] - 2026-08-16
 - **BREAKING**: Changed `SSHClient.identities` getter type from `List<SSHKeyPair>?` to `List<SSHIdentity>?` to support asynchronous external signers (OS agents, hardware tokens, smart cards, Secure Enclave, Android Keystore, and custom signers) [#190]. Constructor invocations passing `List<SSHKeyPair>` remain 100% source-compatible.
@@ -304,6 +304,7 @@
 [#195]: https://github.com/TerminalStudio/dartssh2/pull/195
 [#196]: https://github.com/TerminalStudio/dartssh2/pull/196
 [#197]: https://github.com/TerminalStudio/dartssh2/pull/197
+[#198]: https://github.com/TerminalStudio/dartssh2/pull/198
 
 [@linhanyu]: https://github.com/linhanyu
 [@Migarl]: https://github.com/Migarl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed `SSHClient.run()` and `SSHClient.runWithResult()` hanging forever when the stdout stream emitted an error, by routing stdout errors to the stdout completer [#195]. Thanks [@GT-610].
 - Fixed `SSHClient.run()` and `SSHClient.runWithResult()` raising an uncaught error, instead of throwing to the caller, when the stderr stream emitted an error while stdout was still open. Both streams are now awaited together, and the session is closed on failure so the SSH channel is no longer leaked [#197].
 - Switched SSH protocol randomness to a `Random.secure()` source and widened byte generation to the full `0x00`-`0xff` range, covering key exchange cookies, ephemeral key exchange private values, and OpenSSH private key encryption seeds [#193]. Thanks [@GT-610].
+- Switched the check int of OpenSSH private keys written by `SSHKeyPair.toPem()` to the same secure random source, removing the last insecure `Random()` usage in the library.
 
 ## [3.0.0] - 2026-08-16
 - **BREAKING**: Changed `SSHClient.identities` getter type from `List<SSHKeyPair>?` to `List<SSHIdentity>?` to support asynchronous external signers (OS agents, hardware tokens, smart cards, Secure Enclave, Android Keystore, and custom signers) [#190]. Constructor invocations passing `List<SSHKeyPair>` remain 100% source-compatible.

--- a/lib/src/key_pair/openssh_key_pair.dart
+++ b/lib/src/key_pair/openssh_key_pair.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:dartssh2/src/algorithm/ssh_cipher_type.dart';
@@ -263,7 +262,7 @@ abstract mixin class OpenSSHKeyPair implements SSHKeyPair {
   @override
   String toPem() {
     final writer = SSHMessageWriter();
-    final checkInt = Random().nextInt(0xFFFFFFFF);
+    final checkInt = ByteData.sublistView(randomBytes(4)).getUint32(0);
 
     writer.writeUint32(checkInt);
     writer.writeUint32(checkInt);

--- a/test/src/ssh_key_pair_test.dart
+++ b/test/src/ssh_key_pair_test.dart
@@ -232,6 +232,22 @@ MAA=
     expect(signature1.signature, signature2.signature);
   });
 
+  test('OpenSSHKeyPair.toPem() uses a fresh check int on every call', () async {
+    final keypair = SSHKeyPair.fromPem(rsaPrivateOpenSSH).single;
+
+    final pems = List.generate(4, (_) => keypair.toPem());
+
+    expect(
+      pems.toSet(),
+      hasLength(pems.length),
+      reason: 'the check int must be randomized on every call',
+    );
+
+    for (final pem in pems) {
+      expect(() => SSHKeyPair.fromPem(pem), returnsNormally);
+    }
+  });
+
   test('OpenSSHEcdsaKeyPair.toPem() works', () async {
     final pem1 = ecdsaNistP256Private;
     final keypair1 = SSHKeyPair.fromPem(pem1).single as OpenSSHEcdsaKeyPair;


### PR DESCRIPTION
Follow up to #193, to be included in 3.0.1 before it is published.

#193 moved `randomBytes()` to `Random.secure()`, but `OpenSSHKeyPair.toPem()` still built its check int with `dart:math` `Random()`:

```dart
final checkInt = Random().nextInt(0xFFFFFFFF);
```

That was the last insecure `Random()` left in the library.

## Impact

Low, and I want to be accurate about it rather than overstate it. The check int is not secret material. OpenSSH writes it twice at the start of the private section so that a decryption attempt can tell whether the passphrase was right, and `dartssh2` already reads it back for exactly that purpose. It is not a key, a nonce or a salt.

What it does leak is the state of a predictable generator in a file the user is expected to keep, and `nextInt(0xFFFFFFFF)` could never emit `0xFFFFFFFF`, the same off by one #193 fixed for `randomBytes()`. Neither is worth a security advisory, both are worth not shipping.

## Change

```dart
final checkInt = ByteData.sublistView(randomBytes(4)).getUint32(0);
```

This reuses the secure `randomBytes()` from #193 and covers the full 32 bit range. The `dart:math` import is now unused and removed, so `grep -rn "Random()" lib/` returns nothing outside pointycastle's `FortunaRandom`.

## Test

`OpenSSHKeyPair.toPem() uses a fresh check int on every call` generates the PEM four times and asserts the outputs are all distinct and all parse back. Collision probability over 2^32 is negligible, so it will not flake.

Full suite: 339 tests passing, `dart analyze` clean.

## Out of scope

`hostkey_rsa.dart` passes an unseeded `FortunaRandom()` to `ParametersWithRandom` when building an RSA **verifier**. Verification never draws from it, so it never throws and never matters, but it is dead weight that could be dropped separately.
