### PR TITLE
Register SFTP reply waiters before sending requests

### DIFF
--- a/lib/src/sftp/sftp_client.dart
+++ b/lib/src/sftp/sftp_client.dart
@@ -292,22 +292,25 @@ class SftpClient {
     _channel.addData(writer.takeBytes());
   }
 
+  Future<SftpResponsePacket> _sendRequest(SftpRequestPacket request) async {
+    await handshake;
+    final reply = _waitReply(request.requestId);
+    _sendPacket(request);
+    return await reply;
+  }
+
   Future<SftpResponsePacket> _sendOpen(
     String path,
     SftpFileOpenMode mode,
     SftpFileAttrs attrs,
   ) async {
-    await handshake;
     final request = SftpOpenPacket(_requestId.next, path, mode.flag, attrs);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendClose(Uint8List handle) async {
-    await handshake;
     final request = SftpClosePacket(_requestId.next, handle);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendRead(
@@ -315,15 +318,13 @@ class SftpClient {
     int offset,
     int length,
   ) async {
-    await handshake;
     final request = SftpReadPacket(
       requestId: _requestId.next,
       handle: handle,
       offset: offset,
       length: length,
     );
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendWrite(
@@ -331,135 +332,103 @@ class SftpClient {
     int offset,
     Uint8List data,
   ) async {
-    await handshake;
     final request = SftpWritePacket(
       requestId: _requestId.next,
       handle: handle,
       offset: offset,
       data: data,
     );
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendLStat(String path) async {
-    await handshake;
     final request = SftpLStatPacket(_requestId.next, path);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendFStat(Uint8List handle) async {
-    await handshake;
     final request = SftpFStatPacket(_requestId.next, handle);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendSetStat(
     String path,
     SftpFileAttrs attrs,
   ) async {
-    await handshake;
     final request = SftpSetStatPacket(_requestId.next, path, attrs);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendFSetStat(
     Uint8List handle,
     SftpFileAttrs attrs,
   ) async {
-    await handshake;
     final request = SftpFSetStatPacket(_requestId.next, handle, attrs);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendOpenDir(String path) async {
-    await handshake;
     final request = SftpOpenDirPacket(_requestId.next, path);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendReadDir(Uint8List handle) async {
-    await handshake;
     final request = SftpReadDirPacket(_requestId.next, handle);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendRemove(String filename) async {
-    await handshake;
     final request = SftpRemovePacket(_requestId.next, filename);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendMakeDir(
     String path,
     SftpFileAttrs attrs,
   ) async {
-    await handshake;
     final request = SftpMkdirPacket(_requestId.next, path, attrs);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendRemoveDir(String path) async {
-    await handshake;
     final request = SftpRmdirPacket(_requestId.next, path);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendRealPath(String path) async {
-    await handshake;
     final request = SftpRealpathPacket(_requestId.next, path);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendStat(String path) async {
-    await handshake;
     final request = SftpStatPacket(_requestId.next, path);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendRename(
     String oldPath,
     String newPath,
   ) async {
-    await handshake;
     final request = SftpRenamePacket(_requestId.next, oldPath, newPath);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendReadLink(String path) async {
-    await handshake;
     final request = SftpReadlinkPacket(_requestId.next, path);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendSymlink(
     String linkPath,
     String targetPath,
   ) async {
-    await handshake;
     final request = SftpSymlinkPacket(_requestId.next, linkPath, targetPath);
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   Future<SftpResponsePacket> _sendExtended(SftpExtendedRequest payload) async {
-    await handshake;
     final request = SftpExtendedPacket(_requestId.next, payload.encode());
-    _sendPacket(request);
-    return await _waitReply(request.requestId);
+    return await _sendRequest(request);
   }
 
   void _dispatchReply(SftpResponsePacket packet) {

--- a/test/src/sftp/sftp_client_protocol_test.dart
+++ b/test/src/sftp/sftp_client_protocol_test.dart
@@ -114,6 +114,29 @@ void main() {
       harness.dispose();
     });
 
+    test('request waiter is registered before packet is sent', () async {
+      final channel = _SynchronousResponseChannel();
+      final client = SftpClient(channel);
+
+      channel.sendResponsePacket(SftpVersionPacket(3));
+      await client.handshake;
+
+      channel.respondDuringAddData((payload) {
+        final stat = SftpStatPacket.decode(payload);
+        return SftpAttrsPacket(
+          stat.requestId,
+          SftpFileAttrs(size: 9, mode: const SftpFileMode.value(1 << 15)),
+        );
+      });
+
+      final attrs = await client.stat('/tmp/file').timeout(
+            const Duration(seconds: 1),
+          );
+      expect(attrs.size, 9);
+
+      await client.close();
+    });
+
     test('download keeps chunk order with pipelined reads', () async {
       final harness = _SftpHarness();
       await harness.nextOutgoingPacket();
@@ -591,4 +614,53 @@ class _SftpHarness {
     _controller.destroy();
     _outgoing.close();
   }
+}
+
+class _SynchronousResponseChannel extends SSHChannel {
+  _SynchronousResponseChannel()
+      : super(
+          SSHChannelController(
+            localId: 1,
+            localMaximumPacketSize: 1024 * 1024,
+            localInitialWindowSize: 1024 * 1024,
+            remoteId: 2,
+            remoteMaximumPacketSize: 1024 * 1024,
+            remoteInitialWindowSize: 0,
+            sendMessage: (_) {},
+          ),
+        );
+
+  final _incoming = StreamController<SSHChannelData>(sync: true);
+  SftpPacket Function(Uint8List payload)? _outboundResponder;
+
+  @override
+  Stream<SSHChannelData> get stream => _incoming.stream;
+
+  @override
+  void addData(Uint8List data, {int? type}) {
+    final reader = SSHMessageReader(data);
+    final length = reader.readUint32();
+    final payload = reader.readBytes(length);
+    final response = _outboundResponder?.call(payload);
+    if (response != null) {
+      sendResponsePacket(response);
+    }
+  }
+
+  void respondDuringAddData(
+    SftpPacket Function(Uint8List payload) responder,
+  ) {
+    _outboundResponder = responder;
+  }
+
+  void sendResponsePacket(SftpPacket packet) {
+    final payload = packet.encode();
+    final writer = SSHMessageWriter();
+    writer.writeUint32(payload.length);
+    writer.writeBytes(payload);
+    _incoming.add(SSHChannelData(writer.takeBytes()));
+  }
+
+  @override
+  Future<void> close() => _incoming.close();
 }


### PR DESCRIPTION
SFTP responses are correlated by request ID. Registering the waiter after sending leaves a reentrancy window where a custom or synchronous channel can deliver the response before the request ID is present in the waiter map. The response is then discarded and the operation never completes.

This change records the request state before the packet becomes observable to the channel, matching OpenSSH's ordering of request bookkeeping before sending an SFTP request.
