### PR TITLE
Fix NIST ECDH private scalar generation

### DIFF
--- a/lib/src/kex/kex_nist.dart
+++ b/lib/src/kex/kex_nist.dart
@@ -1,8 +1,7 @@
 import 'dart:typed_data';
 
+import 'package:dartssh2/src/kex/private_scalar.dart';
 import 'package:dartssh2/src/ssh_kex.dart';
-import 'package:dartssh2/src/utils/bigint.dart';
-import 'package:dartssh2/src/utils/list.dart';
 import 'package:dartssh2/src/utils/compute.dart';
 import 'package:pointycastle/ecc/curves/secp256r1.dart';
 import 'package:pointycastle/ecc/curves/secp384r1.dart';
@@ -27,7 +26,7 @@ class SSHKexNist implements SSHKexECDH {
   late final Uint8List publicKey;
 
   SSHKexNist({required this.curve, required this.secretBits}) {
-    privateKey = _generatePrivateKey();
+    privateKey = generateEcPrivateScalar(curve.n);
     final c = curve.G * privateKey;
     publicKey = c!.getEncoded(false);
   }
@@ -78,14 +77,6 @@ class SSHKexNist implements SSHKexECDH {
       (curveName, privateKey, remotePublicKey),
     );
   }
-
-  BigInt _generatePrivateKey() {
-    late BigInt x;
-    do {
-      x = decodeBigIntWithSign(1, randomBytes(secretBits ~/ 8)) % curve.n;
-    } while (x == BigInt.zero);
-    return x;
-  }
 }
 
 ECDomainParameters _getCurveByName(String name) {
@@ -123,12 +114,7 @@ String _getNameByCurve(ECDomainParameters curve) {
 
 (BigInt, Uint8List) _computeNistKeyPair(String curveName) {
   final curve = _getCurveByName(curveName);
-  final secretBits = _getSecretBitsByName(curveName);
-
-  late BigInt x;
-  do {
-    x = decodeBigIntWithSign(1, randomBytes(secretBits ~/ 8)) % curve.n;
-  } while (x == BigInt.zero);
+  final x = generateEcPrivateScalar(curve.n);
 
   final c = curve.G * x;
   final publicKey = c!.getEncoded(false);

--- a/lib/src/kex/private_scalar.dart
+++ b/lib/src/kex/private_scalar.dart
@@ -1,0 +1,37 @@
+import 'dart:typed_data';
+
+import 'package:dartssh2/src/utils/bigint.dart';
+import 'package:dartssh2/src/utils/list.dart' as list_utils;
+
+/// Generates an unbiased private scalar in the range `1 <= scalar < order`.
+BigInt generateEcPrivateScalar(
+  BigInt order, {
+  Uint8List Function(int length)? randomBytes,
+}) {
+  if (order <= BigInt.one) {
+    throw ArgumentError.value(order, 'order', 'Must be greater than one');
+  }
+
+  final bitLength = order.bitLength;
+  final byteLength = (bitLength + 7) ~/ 8;
+  final excessBits = byteLength * 8 - bitLength;
+  final byteSource = randomBytes ?? list_utils.randomBytes;
+
+  while (true) {
+    final bytes = Uint8List.fromList(byteSource(byteLength));
+    if (bytes.length != byteLength) {
+      throw ArgumentError(
+        'Random byte source must return exactly $byteLength bytes',
+      );
+    }
+
+    if (excessBits != 0) {
+      bytes[0] &= 0xff >> excessBits;
+    }
+
+    final candidate = decodeBigIntWithSign(1, bytes);
+    if (candidate > BigInt.zero && candidate < order) {
+      return candidate;
+    }
+  }
+}

--- a/test/src/kex/kex_nist_test.dart
+++ b/test/src/kex/kex_nist_test.dart
@@ -66,6 +66,13 @@ void main() {
       expect(privateKey < kex.curve.n, isTrue,
           reason: 'Private key should be less than curve order.');
     });
+
+    test('generate P-521 private key within valid range', () {
+      final kex = SSHKexNist.p521();
+
+      expect(kex.privateKey, greaterThan(BigInt.zero));
+      expect(kex.privateKey, lessThan(kex.curve.n));
+    });
   });
 
   group('SSHKexNist (Async)', () {
@@ -94,6 +101,14 @@ void main() {
       final secret1 = await kex1.computeSecretAsync(kex2.publicKey);
       final secret2 = await kex2.computeSecretAsync(kex1.publicKey);
       expect(secret1, equals(secret2));
+    });
+
+    test('generate P-521 private key within valid range asynchronously',
+        () async {
+      final kex = await SSHKexNist.p521Async();
+
+      expect(kex.privateKey, greaterThan(BigInt.zero));
+      expect(kex.privateKey, lessThan(kex.curve.n));
     });
   });
 }

--- a/test/src/kex/private_scalar_test.dart
+++ b/test/src/kex/private_scalar_test.dart
@@ -1,0 +1,80 @@
+import 'dart:typed_data';
+
+import 'package:dartssh2/src/kex/private_scalar.dart';
+import 'package:pointycastle/ecc/curves/secp521r1.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final order = ECCurve_secp521r1().n;
+  const byteLength = 66;
+
+  group('generateEcPrivateScalar', () {
+    test('uses all 521 bits and masks unused high bits', () {
+      var requestedLength = 0;
+      final input = Uint8List(byteLength)..[0] = 0xff;
+
+      final scalar = generateEcPrivateScalar(
+        order,
+        randomBytes: (length) {
+          requestedLength = length;
+          return input;
+        },
+      );
+
+      expect(requestedLength, byteLength);
+      expect(scalar, BigInt.one << 520);
+      expect(input[0], 0xff, reason: 'The source buffer must not be modified.');
+    });
+
+    test('rejects zero', () {
+      var calls = 0;
+
+      final scalar = generateEcPrivateScalar(
+        order,
+        randomBytes: (_) {
+          calls++;
+          if (calls == 1) return Uint8List(byteLength);
+          return Uint8List(byteLength)..[byteLength - 1] = 1;
+        },
+      );
+
+      expect(calls, 2);
+      expect(scalar, BigInt.one);
+    });
+
+    test('rejects the curve order', () {
+      var calls = 0;
+
+      final scalar = generateEcPrivateScalar(
+        order,
+        randomBytes: (_) {
+          calls++;
+          if (calls == 1) return _encodeUnsigned(order, byteLength);
+          return Uint8List(byteLength)..[byteLength - 1] = 2;
+        },
+      );
+
+      expect(calls, 2);
+      expect(scalar, BigInt.two);
+    });
+
+    test('rejects a random byte source with the wrong length', () {
+      expect(
+        () => generateEcPrivateScalar(
+          order,
+          randomBytes: (_) => Uint8List(byteLength - 1),
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}
+
+Uint8List _encodeUnsigned(BigInt value, int length) {
+  final result = Uint8List(length);
+  for (var i = length - 1; i >= 0; i--) {
+    result[i] = (value & BigInt.from(0xff)).toInt();
+    value >>= 8;
+  }
+  return result;
+}


### PR DESCRIPTION
P-521 previously used `secretBits ~/ 8`, so it sampled only 65 bytes and could never set the 521st bit. Reducing candidates modulo the curve order also introduces distribution bias.

OpenSSH delegates NIST ECDH key generation to `EC_KEY_generate_key()`. This change provides the equivalent private-scalar range and uniformity properties in Dart while continuing to use the package's `Random.secure()`-backed byte source.