### PR TITLE
fix: retry short SFTP reads without collapsing the request size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [3.0.2] - 2026-08-17
+- Fixed silent data loss in SFTP reads when a server returned fewer bytes than requested, which the protocol allows: the missing suffix is now retried instead of skipped, so `SftpFile.read()` and `SftpClient.download()` no longer return truncated, misaligned data [#200] [#203]. Thanks [@GT-610].
+- Fixed NIST ECDH private scalar generation, which sampled only 65 bytes for P-521 and could therefore never set the 521st bit, and replaced the modulo reduction with rejection sampling for a uniform scalar in `1 <= x < n` [#201]. Thanks [@GT-610].
+- Changed `SftpFile.read()` to process pipelined read replies as they arrive while still emitting chunks ordered by file offset [#200]. Thanks [@GT-610].
+- Changed `SftpFile.read()` to throw `SftpError` when a server returns more bytes than requested, instead of silently truncating the surplus [#200]. Thanks [@GT-610].
+- Registered SFTP reply waiters before sending each request, so a reply can no longer be discarded by a channel that delivers it synchronously [#199]. Thanks [@GT-610].
+- Limited SFTP read resizing to short replies of at least 512 bytes, so a single tiny reply no longer pins every later request to that floor for the rest of a transfer [#203].
+
 ## [3.0.1] - 2026-08-16
 - Fixed X11 forwarding by encoding and decoding the `x11-req` screen number as a `uint32` instead of a string, as required by RFC 4254 §6.3 [#194]. Thanks [@GT-610].
 - Fixed `SSHChannel.remoteChannelId` returning the local channel id instead of the id assigned by the peer [#196]. Thanks [@GT-610].
@@ -305,6 +313,10 @@
 [#196]: https://github.com/vicajilau/dartssh2/pull/196
 [#197]: https://github.com/vicajilau/dartssh2/pull/197
 [#198]: https://github.com/vicajilau/dartssh2/pull/198
+[#199]: https://github.com/vicajilau/dartssh2/pull/199
+[#200]: https://github.com/vicajilau/dartssh2/pull/200
+[#201]: https://github.com/vicajilau/dartssh2/pull/201
+[#203]: https://github.com/vicajilau/dartssh2/pull/203
 
 [@linhanyu]: https://github.com/linhanyu
 [@Migarl]: https://github.com/Migarl

--- a/lib/src/sftp/sftp_client.dart
+++ b/lib/src/sftp/sftp_client.dart
@@ -23,6 +23,8 @@ part 'sftp_file.dart';
 const _kVersion = 3;
 const _kReadChunkSize = 16 * 1024;
 const _kReadMaxPendingRequests = 64;
+// Keep adaptive reads from collapsing to tiny packets after a short reply.
+const _kMinReadSize = 512;
 const _kDownloadChunkSize = 64 * 1024;
 const _kDownloadMaxPendingRequests = 128;
 

--- a/lib/src/sftp/sftp_client.dart
+++ b/lib/src/sftp/sftp_client.dart
@@ -23,7 +23,9 @@ part 'sftp_file.dart';
 const _kVersion = 3;
 const _kReadChunkSize = 16 * 1024;
 const _kReadMaxPendingRequests = 64;
-// Keep adaptive reads from collapsing to tiny packets after a short reply.
+// Short replies below this size are treated as a hiccup rather than as the
+// server's real read capacity, so they do not shrink later requests.
+// Mirrors `MIN_READ_SIZE` in OpenSSH's `sftp-client.c`.
 const _kMinReadSize = 512;
 const _kDownloadChunkSize = 64 * 1024;
 const _kDownloadMaxPendingRequests = 128;

--- a/lib/src/sftp/sftp_file.dart
+++ b/lib/src/sftp/sftp_file.dart
@@ -159,10 +159,17 @@ class SftpFile {
           completedReads[startOffset] = chunk;
 
           if (chunk.length < requestLength) {
-            effectiveChunkSize = min(
-              chunkSize,
-              max(_kMinReadSize, chunk.length),
-            );
+            // OpenSSH clamps the request size down to a short reply, with a
+            // 512 byte floor (`MIN_READ_SIZE` in `sftp-client.c`). We clamp
+            // the same way, but only when the reply is large enough to look
+            // like the server's real capacity. Clamping to the floor instead
+            // would let a single tiny reply pin every later request at 512
+            // bytes for the rest of the transfer, which costs far more here
+            // than it does in OpenSSH: this pipeline defaults to 64 KB reads
+            // with up to 128 of them in flight.
+            if (chunk.length >= _kMinReadSize) {
+              effectiveChunkSize = min(effectiveChunkSize, chunk.length);
+            }
             issueRead(
               startOffset + chunk.length,
               requestLength - chunk.length,

--- a/lib/src/sftp/sftp_file.dart
+++ b/lib/src/sftp/sftp_file.dart
@@ -38,8 +38,9 @@ class SftpFile {
     SftpStatusError.check(reply);
   }
 
-  /// Reads at most [count] bytes from the file starting at [offset]. If
-  /// [length] is null, reads until end of file.  Returns a [Stream] of chunks.
+  /// Reads at most [length] bytes from the file starting at [offset]. If
+  /// [length] is null, reads until end of file. Returns a [Stream] of chunks
+  /// ordered by file offset, even if the server replies out of order.
   /// [onProgress] is called with the total number of bytes already read.
   /// Use [readBytes] if you want a single Uint8List.
   Stream<Uint8List> read({
@@ -80,35 +81,146 @@ class SftpFile {
     }
 
     final endOffset = offset + length;
-    final pendingReads = <Future<Uint8List?>>[];
-    var nextOffset = offset;
+    final completedReads = <int, Uint8List?>{};
+    var reservedOffset = offset;
     var bytesRead = 0;
+    var nextOutputOffset = offset;
+    var pendingReadCount = 0;
+    var activeReadLimit = 1;
+    var effectiveChunkSize = chunkSize;
+    var stopScheduling = false;
+    var outputEnded = false;
+    Object? pendingError;
+    StackTrace? pendingStackTrace;
+    Completer<void>? completionSignal;
+
+    void notifyReadComplete() {
+      final signal = completionSignal;
+      if (signal != null && !signal.isCompleted) {
+        signal.complete();
+      }
+    }
+
+    Future<void> waitForReadComplete() {
+      final signal = completionSignal = Completer<void>();
+      return signal.future.whenComplete(() {
+        if (identical(completionSignal, signal)) {
+          completionSignal = null;
+        }
+      });
+    }
+
+    void recordError(Object error, StackTrace stackTrace) {
+      if (pendingError != null) return;
+      pendingError = error;
+      pendingStackTrace = stackTrace;
+      stopScheduling = true;
+    }
+
+    void issueRead(int startOffset, int requestLength) {
+      pendingReadCount++;
+      _readChunk(requestLength, startOffset).then(
+        (chunk) {
+          pendingReadCount--;
+
+          if (pendingError != null) {
+            notifyReadComplete();
+            return;
+          }
+
+          if (chunk == null) {
+            stopScheduling = true;
+            completedReads[startOffset] = null;
+            notifyReadComplete();
+            return;
+          }
+
+          if (chunk.length > requestLength) {
+            recordError(
+              SftpError(
+                'Received ${chunk.length} bytes for a $requestLength-byte read',
+              ),
+              StackTrace.current,
+            );
+            notifyReadComplete();
+            return;
+          }
+
+          if (chunk.isEmpty) {
+            recordError(
+              SftpError('Unexpected empty data chunk before EOF'),
+              StackTrace.current,
+            );
+            notifyReadComplete();
+            return;
+          }
+
+          activeReadLimit = min(maxPendingRequests, activeReadLimit + 1);
+          completedReads[startOffset] = chunk;
+
+          if (chunk.length < requestLength) {
+            effectiveChunkSize = min(
+              chunkSize,
+              max(_kMinReadSize, chunk.length),
+            );
+            issueRead(
+              startOffset + chunk.length,
+              requestLength - chunk.length,
+            );
+          }
+
+          notifyReadComplete();
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          pendingReadCount--;
+          recordError(error, stackTrace);
+          notifyReadComplete();
+        },
+      );
+    }
+
+    void scheduleReads() {
+      while (!stopScheduling &&
+          reservedOffset < endOffset &&
+          pendingReadCount < activeReadLimit &&
+          completedReads.length < maxPendingRequests) {
+        final startOffset = reservedOffset;
+        final requestLength =
+            min(effectiveChunkSize, endOffset - reservedOffset);
+        issueRead(startOffset, requestLength);
+        reservedOffset += requestLength;
+      }
+    }
+
+    scheduleReads();
 
     while (bytesRead < length) {
-      while (
-          nextOffset < endOffset && pendingReads.length < maxPendingRequests) {
-        final requestLength = min(chunkSize, endOffset - nextOffset);
-        pendingReads.add(_readChunk(requestLength, nextOffset));
-        nextOffset += requestLength;
+      if (pendingError != null) {
+        Error.throwWithStackTrace(pendingError!, pendingStackTrace!);
       }
 
-      if (pendingReads.isEmpty) break;
+      if (!outputEnded && completedReads.containsKey(nextOutputOffset)) {
+        final chunk = completedReads.remove(nextOutputOffset);
+        if (chunk == null) {
+          outputEnded = true;
+        } else {
+          nextOutputOffset += chunk.length;
+          bytesRead += chunk.length;
+          scheduleReads();
 
-      final chunk = await pendingReads.removeAt(0);
-      if (chunk == null) break;
-      if (chunk.isEmpty) {
-        throw SftpError('Unexpected empty data chunk before EOF');
+          yield chunk;
+          onProgress?.call(bytesRead);
+          continue;
+        }
       }
 
-      final remaining = length - bytesRead;
-      final outputChunk = chunk.length <= remaining
-          ? chunk
-          : Uint8List.sublistView(chunk, 0, remaining);
-
-      yield outputChunk;
-
-      bytesRead += outputChunk.length;
-      onProgress?.call(bytesRead);
+      scheduleReads();
+      if (outputEnded) {
+        if (pendingReadCount == 0) break;
+      } else if (pendingReadCount == 0) {
+        break;
+      }
+      await waitForReadComplete();
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartssh2
-version: 3.0.1
+version: 3.0.2
 description: SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as easy to use.
 homepage: https://github.com/vicajilau/dartssh2
 repository: https://github.com/vicajilau/dartssh2

--- a/test/src/sftp/sftp_client_protocol_test.dart
+++ b/test/src/sftp/sftp_client_protocol_test.dart
@@ -137,7 +137,8 @@ void main() {
       await client.close();
     });
 
-    test('download keeps chunk order with pipelined reads', () async {
+    test('read ramps and replenishes its pipeline for out-of-order replies',
+        () async {
       final harness = _SftpHarness();
       await harness.nextOutgoingPacket();
       harness.sendResponsePacket(SftpVersionPacket(3));
@@ -147,7 +148,7 @@ void main() {
       final downloadFuture = harness.client.download(
         '/tmp/file',
         sink,
-        length: 8,
+        length: 16,
         chunkSize: 4,
         maxPendingRequests: 2,
       );
@@ -158,16 +159,31 @@ void main() {
       );
 
       final read1 = SftpReadPacket.decode(await harness.nextOutgoingPacket());
-      final read2 = SftpReadPacket.decode(await harness.nextOutgoingPacket());
-
       expect(read1.offset, 0);
-      expect(read2.offset, 4);
 
-      harness.sendResponsePacket(
-        SftpDataPacket(read2.requestId, Uint8List.fromList('EFGH'.codeUnits)),
-      );
+      final nextReads = harness.nextOutgoingPackets(2);
       harness.sendResponsePacket(
         SftpDataPacket(read1.requestId, Uint8List.fromList('ABCD'.codeUnits)),
+      );
+
+      final reads = (await nextReads).map(SftpReadPacket.decode).toList();
+      final read2 = reads[0];
+      final read3 = reads[1];
+      expect(read2.offset, 4);
+      expect(read3.offset, 8);
+
+      final read4Future = harness.nextOutgoingPacket();
+      harness.sendResponsePacket(
+        SftpDataPacket(read3.requestId, Uint8List.fromList('IJKL'.codeUnits)),
+      );
+      final read4 = SftpReadPacket.decode(await read4Future);
+      expect(read4.offset, 12);
+
+      harness.sendResponsePacket(
+        SftpDataPacket(read4.requestId, Uint8List.fromList('MNOP'.codeUnits)),
+      );
+      harness.sendResponsePacket(
+        SftpDataPacket(read2.requestId, Uint8List.fromList('EFGH'.codeUnits)),
       );
 
       final close = SftpClosePacket.decode(await harness.nextOutgoingPacket());
@@ -180,8 +196,81 @@ void main() {
       );
 
       final bytes = await downloadFuture;
-      expect(bytes, 8);
-      expect(sink.bytes, Uint8List.fromList('ABCDEFGH'.codeUnits));
+      expect(bytes, 16);
+      expect(sink.bytes, Uint8List.fromList('ABCDEFGHIJKLMNOP'.codeUnits));
+
+      harness.dispose();
+    });
+
+    test('read retries the missing suffix after a short data packet', () async {
+      final harness = _SftpHarness();
+      await harness.nextOutgoingPacket();
+      harness.sendResponsePacket(SftpVersionPacket(3));
+      await harness.client.handshake;
+
+      final sink = _CollectingSink();
+      final downloadFuture = harness.client.download(
+        '/tmp/file',
+        sink,
+        length: 1536,
+        chunkSize: 1024,
+        maxPendingRequests: 2,
+      );
+
+      final open = SftpOpenPacket.decode(await harness.nextOutgoingPacket());
+      harness.sendResponsePacket(
+        SftpHandlePacket(open.requestId, Uint8List.fromList([1, 2, 3])),
+      );
+
+      final read1 = SftpReadPacket.decode(await harness.nextOutgoingPacket());
+      expect(read1.offset, 0);
+      expect(read1.length, 1024);
+
+      final nextReads = harness.nextOutgoingPackets(2);
+      harness.sendResponsePacket(
+        SftpDataPacket(read1.requestId, Uint8List.fromList([1])),
+      );
+
+      final reads = (await nextReads).map(SftpReadPacket.decode).toList();
+      final retry = reads[0];
+      final read2 = reads[1];
+      expect(retry.offset, 1);
+      expect(retry.length, 1023);
+      expect(read2.offset, 1024);
+      expect(read2.length, 512);
+
+      harness.sendResponsePacket(
+        SftpDataPacket(
+          read2.requestId,
+          Uint8List.fromList(List<int>.filled(512, 3)),
+        ),
+      );
+      harness.sendResponsePacket(
+        SftpDataPacket(
+          retry.requestId,
+          Uint8List.fromList(List<int>.filled(1023, 2)),
+        ),
+      );
+
+      final close = SftpClosePacket.decode(await harness.nextOutgoingPacket());
+      harness.sendResponsePacket(
+        SftpStatusPacket(
+          requestId: close.requestId,
+          code: SftpStatusCode.ok,
+          message: 'ok',
+        ),
+      );
+
+      final bytes = await downloadFuture;
+      expect(bytes, 1536);
+      expect(
+        sink.bytes,
+        Uint8List.fromList([
+          1,
+          ...List<int>.filled(1023, 2),
+          ...List<int>.filled(512, 3),
+        ]),
+      );
 
       harness.dispose();
     });
@@ -583,6 +672,9 @@ class _SftpHarness {
   }
 
   Future<Uint8List> nextOutgoingPacket() => _outgoing.stream.first;
+
+  Future<List<Uint8List>> nextOutgoingPackets(int count) =>
+      _outgoing.stream.take(count).toList();
 
   Future<void> get channelDone => _controller.channel.done;
 

--- a/test/src/sftp/sftp_client_protocol_test.dart
+++ b/test/src/sftp/sftp_client_protocol_test.dart
@@ -704,9 +704,8 @@ Future<List<int>> _recordReadLengths({
     final read = SftpReadPacket.decode(packet);
     requestedLengths.add(read.length);
 
-    final replyLength = requestedLengths.length == 1
-        ? firstReplyLength
-        : read.length;
+    final replyLength =
+        requestedLengths.length == 1 ? firstReplyLength : read.length;
     delivered += replyLength;
 
     harness.sendResponsePacket(

--- a/test/src/sftp/sftp_client_protocol_test.dart
+++ b/test/src/sftp/sftp_client_protocol_test.dart
@@ -202,6 +202,30 @@ void main() {
       harness.dispose();
     });
 
+    test('a one-off tiny reply does not shrink later reads', () async {
+      final lengths = await _recordReadLengths(
+        totalLength: 8192 * 3,
+        chunkSize: 8192,
+        firstReplyLength: 1,
+      );
+
+      // The suffix is retried, and the reads after it stay at full size
+      // instead of being pinned to the 512 byte floor.
+      expect(lengths, [8192, 8191, 8192, 8192]);
+    });
+
+    test('a large short reply clamps later reads, as OpenSSH does', () async {
+      final lengths = await _recordReadLengths(
+        totalLength: 8192 * 3,
+        chunkSize: 8192,
+        firstReplyLength: 4096,
+      );
+
+      // A reply this size reads as the server's real capacity, so the client
+      // settles there and stops asking for more than the server will give.
+      expect(lengths, [8192, 4096, 4096, 4096, 4096, 4096]);
+    });
+
     test('read retries the missing suffix after a short data packet', () async {
       final harness = _SftpHarness();
       await harness.nextOutgoingPacket();
@@ -641,6 +665,72 @@ class _CollectingSink implements StreamSink<List<int>> {
 
   @override
   Future<void> get done => _done.future;
+}
+
+/// Downloads [totalLength] bytes, answering the first read with only
+/// [firstReplyLength] bytes and filling every read after it, and returns the
+/// length the client asked for on each read request.
+Future<List<int>> _recordReadLengths({
+  required int totalLength,
+  required int chunkSize,
+  required int firstReplyLength,
+}) async {
+  final harness = _SftpHarness();
+  await harness.nextOutgoingPacket();
+  harness.sendResponsePacket(SftpVersionPacket(3));
+  await harness.client.handshake;
+
+  final sink = _CollectingSink();
+  final downloadFuture = harness.client.download(
+    '/tmp/file',
+    sink,
+    length: totalLength,
+    chunkSize: chunkSize,
+    maxPendingRequests: 1,
+  );
+
+  final open = SftpOpenPacket.decode(await harness.nextOutgoingPacket());
+  harness.sendResponsePacket(
+    SftpHandlePacket(open.requestId, Uint8List.fromList([1, 2, 3])),
+  );
+
+  final requestedLengths = <int>[];
+  var delivered = 0;
+
+  while (delivered < totalLength) {
+    final packet = await harness.nextOutgoingPacket();
+    if (packet[0] != SftpReadPacket.packetType) break;
+
+    final read = SftpReadPacket.decode(packet);
+    requestedLengths.add(read.length);
+
+    final replyLength = requestedLengths.length == 1
+        ? firstReplyLength
+        : read.length;
+    delivered += replyLength;
+
+    harness.sendResponsePacket(
+      SftpDataPacket(
+        read.requestId,
+        Uint8List.fromList(List<int>.filled(replyLength, 7)),
+      ),
+    );
+  }
+
+  final close = SftpClosePacket.decode(await harness.nextOutgoingPacket());
+  harness.sendResponsePacket(
+    SftpStatusPacket(
+      requestId: close.requestId,
+      code: SftpStatusCode.ok,
+      message: 'ok',
+    ),
+  );
+
+  expect(await downloadFuture, totalLength);
+  expect(sink.bytes, hasLength(totalLength));
+
+  harness.dispose();
+  return requestedLengths;
 }
 
 class _SftpHarness {


### PR DESCRIPTION
Supersedes #200, carrying @GT-610's original commit plus one fix on top.

I could not push to the source branch on the `lollipopkit` fork, so this reopens the same work here rather than editing #200 in place. **The original commit keeps its authorship**, this is not a reimplementation.

## What #200 found

A server is allowed by the SFTP spec to return fewer bytes than requested, and the read pipeline skipped the gap instead of retrying it. Probed against `master` before this branch, asking for 8 bytes with `chunkSize: 4` and answering the first read with a single byte:

```
read1 offset=0 length=4   -> replied with 1 byte
next packet: read offset=4     <- offsets 1..3 are never requested
download() returned 5 bytes: [65, 66, 66, 66, 66]
```

`download()` returned **successfully** with truncated, misaligned data. Silent corruption, and the most valuable find in this round of PRs.

## What this branch adds

@GT-610's implementation mirrors OpenSSH closely, including clamping the request size down to a short reply with a 512 byte floor. I verified that in `sftp-client.c`:

```c
#define MIN_READ_SIZE	512                     /* line 66 */
...
/* Reduce the request size */
if (len < buflen)
    buflen = MAXIMUM(MIN_READ_SIZE, len);       /* lines 1782-1784 */
```

The floor has a sharp edge, which I measured on the branch with an 8 KB chunk size, one single 1-byte reply at the start, and a well behaved server after it:

```
requested read sizes: [8192, 8191, 512, 512, 512, 512, 512, 512, ...]
```

One tiny reply pins every later request at 512 bytes for the rest of the transfer, with no way back up. OpenSSH has the same edge, but it costs far more here: this pipeline defaults to 64 KB reads with up to 128 in flight, so a 1 GB download would turn roughly 16k round trips into roughly 2 million.

The added commit clamps only when the short reply is at least `MIN_READ_SIZE`, which is the case where it genuinely signals the server's read capacity. Smaller replies still get their missing suffix retried, they just stop resizing anything. This is a deliberate divergence from OpenSSH, not a correction of it.

Two tests, one on each side of the threshold. The first fails without the added commit:

| Test | Expects |
|---|---|
| `a one-off tiny reply does not shrink later reads` | `[8192, 8191, 8192, 8192]` |
| `a large short reply clamps later reads, as OpenSSH does` | `[8192, 4096, 4096, 4096, 4096, 4096]` |

## Notes

- The ramp from one in-flight read upward matches OpenSSH (`max_req = 1` then `++max_req` per reply), but it does reduce initial parallelism compared to what this library did before, which issued `maxPendingRequests` immediately. Accepted deliberately.
- A server returning **more** bytes than requested now throws `SftpError` instead of being silently truncated. Better behaviour, and it is called out in the changelog as an observable change.

349 tests passing, `dart analyze` clean.
