### PR TITLE
chore: follow the default branch rename from master to main

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -53,7 +53,9 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v7
         with:
-          fail_ci_if_error: false # optional (default = false)
+          # Fail loudly. With this off, the upload 404'd for every run after
+          # the repository moved owners and the step still reported success.
+          fail_ci_if_error: true
           files: ./coverage/lcov.info # optional
           flags: unittests # optional
           name: codecov-umbrella # optional

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -3,10 +3,10 @@ name: Dart
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test:
@@ -47,7 +47,7 @@ jobs:
         run: dart pub global run coverage:format_coverage --lcov --in=coverage/test --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=lib
 
       - name: Run integration tests
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: dart test --tags=integration
 
       - name: Upload coverage

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as e
   <tr> 
     <!-- ServerBox -->
     <td>
-      <img src="https://raw.githubusercontent.com/vicajilau/dartssh2/master/media/showcase-1-serverbox.1.jpg" width="150px" alt="ServerBox interface displaying connection management options">
-      <img src="https://raw.githubusercontent.com/vicajilau/dartssh2/master/media/showcase-1-serverbox.2.png" width="150px" alt="ServerBox user interface for server control and monitoring">
+      <img src="https://raw.githubusercontent.com/vicajilau/dartssh2/main/media/showcase-1-serverbox.1.jpg" width="150px" alt="ServerBox interface displaying connection management options">
+      <img src="https://raw.githubusercontent.com/vicajilau/dartssh2/main/media/showcase-1-serverbox.2.png" width="150px" alt="ServerBox user interface for server control and monitoring">
     </td>
     <!-- NoPorts -->
     <td>
@@ -666,20 +666,20 @@ void main() async {
 
 ### SSH client:
 
-- [example/example.dart](https://github.com/vicajilau/dartssh2/blob/master/example/example.dart)
-- [example/execute.dart](https://github.com/vicajilau/dartssh2/blob/master/example/execute.dart)
-- [example/forward_local.dart](https://github.com/vicajilau/dartssh2/blob/master/example/forward_local.dart)
-- [example/forward_remote.dart](https://github.com/vicajilau/dartssh2/blob/master/example/forward_remote.dart)
-- [example/pubkey.dart](https://github.com/vicajilau/dartssh2/blob/master/example/pubkey.dart)
-- [example/shell.dart](https://github.com/vicajilau/dartssh2/blob/master/example/shell.dart)
-- [example/ssh_jump.dart](https://github.com/vicajilau/dartssh2/blob/master/example/ssh_jump.dart)
+- [example/example.dart](https://github.com/vicajilau/dartssh2/blob/main/example/example.dart)
+- [example/execute.dart](https://github.com/vicajilau/dartssh2/blob/main/example/execute.dart)
+- [example/forward_local.dart](https://github.com/vicajilau/dartssh2/blob/main/example/forward_local.dart)
+- [example/forward_remote.dart](https://github.com/vicajilau/dartssh2/blob/main/example/forward_remote.dart)
+- [example/pubkey.dart](https://github.com/vicajilau/dartssh2/blob/main/example/pubkey.dart)
+- [example/shell.dart](https://github.com/vicajilau/dartssh2/blob/main/example/shell.dart)
+- [example/ssh_jump.dart](https://github.com/vicajilau/dartssh2/blob/main/example/ssh_jump.dart)
 
 ### SFTP:
-- [example/sftp_read.dart](https://github.com/vicajilau/dartssh2/blob/master/example/sftp_read.dart)
-- [example/sftp_list.dart](https://github.com/vicajilau/dartssh2/blob/master/example/sftp_list.dart)
-- [example/sftp_stat.dart](https://github.com/vicajilau/dartssh2/blob/master/example/sftp_stat.dart)
-- [example/sftp_upload.dart](https://github.com/vicajilau/dartssh2/blob/master/example/sftp_upload.dart)
-- [example/sftp_filetype.dart](https://github.com/vicajilau/dartssh2/blob/master/example/sftp_filetype.dart)
+- [example/sftp_read.dart](https://github.com/vicajilau/dartssh2/blob/main/example/sftp_read.dart)
+- [example/sftp_list.dart](https://github.com/vicajilau/dartssh2/blob/main/example/sftp_list.dart)
+- [example/sftp_stat.dart](https://github.com/vicajilau/dartssh2/blob/main/example/sftp_stat.dart)
+- [example/sftp_upload.dart](https://github.com/vicajilau/dartssh2/blob/main/example/sftp_upload.dart)
+- [example/sftp_filetype.dart](https://github.com/vicajilau/dartssh2/blob/main/example/sftp_filetype.dart)
 
 
 


### PR DESCRIPTION
Follow up to renaming the default branch from `master` to `main`.

## CI was silently switched off

`.github/workflows/dart.yml` only triggered on `master`:

```yaml
on:
  push:
    branches:
      - master
  pull_request:
    branches:
      - master
```

After the rename that matches nothing. Pushes to `main` run no jobs, and pull requests targeting `main` show no checks at all rather than a failure, which is the dangerous shape of this: it looks like everything is fine.

A third spot had the same problem. The integration test step was gated on the branch ref:

```yaml
if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
```

so integration tests would have stayed silent on every push even after fixing the triggers.

## README links pinned to the old branch

13 links pinned `/blob/master/` or `raw.githubusercontent.com/.../master/`. github.com redirects a renamed default branch, so the `blob` links would survive, but `raw.githubusercontent.com` does not follow that redirect, which puts the two showcase images at real risk. Same failure mode as the org migration in #202.

One `master` link is deliberately left alone: it points at `lschaffer/tealkit`, another project's repository.

## Note on checks for this PR

For `pull_request` events GitHub evaluates the workflow from the merge result, so this PR should be the first one to run checks again. If it still shows none, the fix is confirmed by that absence and the workflow becomes live the moment it lands on `main`.
