### PR TITLE
feat: mitigate Terrapin, harden default algorithms, and cover the crypto paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [3.1.0] - 2026-08-17
+- Added strict key exchange (`kex-strict-c-v00@openssh.com`), the countermeasure against the Terrapin attack (CVE-2023-48795). It is negotiated automatically and, when the server supports it, packet sequence numbers are reset after every `SSH_MSG_NEWKEYS`, `SSH_MSG_IGNORE` / `SSH_MSG_UNIMPLEMENTED` / `SSH_MSG_DEBUG` are rejected during a key exchange, and the first `SSH_MSG_KEXINIT` is required to be the first packet of the connection. Exposed as `SSHClient.strictKex`.
+- Added `SSH_MSG_EXT_INFO` support (RFC 8308). The client advertises `ext-info-c` and exposes the signature algorithms the server accepts as `SSHClient.serverSigAlgs`.
+- **Changed the default algorithm preferences.** AES-GCM is now the preferred cipher instead of being opt-in, encrypt-then-MAC is preferred over encrypt-and-MAC, and `ssh-rsa` (SHA-1) is now last among the host key algorithms. CBC ciphers and `hmac-sha1` remain available but are only reached when a server offers nothing better.
+- **Removed three broken algorithms from the defaults**: `diffie-hellman-group1-sha1` (1024-bit group), `hmac-md5`, and the truncated `hmac-sha2-[256|512]-96` variants. They are still implemented and can be re-enabled by passing them to `SSHAlgorithms` explicitly.
+- Fixed `SSH_Message_Userauth_Request.decode()` swapping the old and new password when decoding a password change request, contrary to RFC 4252 §8.
+- Fixed `SSH_Message_Userauth_Request.decode()` not reading the boolean that precedes the algorithm name in a `publickey` request (RFC 4252 §7), which misparsed every signed request and could not represent an unsigned probe.
+- Added a `SECURITY.md` with a private vulnerability reporting process.
+- Documented `onVerifyHostKey` in the README. Host key signatures were and are always verified, but deciding whether the key is the expected one is the caller's job, and omitting the handler accepts any host key.
+
 ## [3.0.2] - 2026-08-17
 - Fixed silent data loss in SFTP reads when a server returned fewer bytes than requested, which the protocol allows: the missing suffix is now retried instead of skipped, so `SftpFile.read()` and `SftpClient.download()` no longer return truncated, misaligned data [#200] [#203]. Thanks [@GT-610].
 - Fixed NIST ECDH private scalar generation, which sampled only 65 bytes for P-521 and could therefore never set the 521st bit, and replaced the modulo reduction with rejection sampling for a uniform scalar in `1 <= x < n` [#201]. Thanks [@GT-610].

--- a/README.md
+++ b/README.md
@@ -129,6 +129,42 @@ void main() async {
 
 > `SSHSocket` is an interface and it's possible to implement your own `SSHSocket` if you want to use a different underlying transport rather than standard TCP socket. For example WebSocket or Unix domain socket.
 
+### Verify the host key
+
+The example above authenticates the *server to nobody*: dartssh2 always checks
+that the host key signature is valid, which proves the server owns the private
+key it presented, but it cannot know whether that key is the one you expected.
+Without that second check, an attacker who can intercept the connection can
+present their own key and read the whole session.
+
+Pass `onVerifyHostKey` to decide whether the key is trusted. It receives the
+key type and the OpenSSH-style SHA256 fingerprint, and returning `false`
+aborts the connection:
+
+```dart
+final client = SSHClient(
+  await SSHSocket.connect('localhost', 22),
+  username: '<username>',
+  onPasswordRequest: () => '<password>',
+  onVerifyHostKey: (type, fingerprint) {
+    final expected = knownHosts['localhost']; // your own storage
+    if (expected == null) {
+      // First connection: ask the user, then remember the answer.
+      return promptUserToTrust(type, utf8.decode(fingerprint));
+    }
+    return utf8.decode(fingerprint) == expected;
+  },
+);
+```
+
+The handler may return a `Future<bool>`, so it can await a UI prompt or a
+lookup in persistent storage. When `onVerifyHostKey` is omitted, **every host
+key is accepted**, which is only appropriate for tests and for networks you
+already trust end to end.
+
+> `disableHostkeyVerification: true` is a separate and stronger opt-out: it
+> skips the signature check as well. Do not use it outside of local testing.
+
 ### Web support
 
 Direct native TCP sockets are not available in browsers, so this will fail on
@@ -703,9 +739,35 @@ void main() async {
 - `aes[128|192|256]-ctr`
 - `aes[128|192|256]-cbc`
 
-AES-GCM is currently available as opt-in via `SSHAlgorithms(cipher: ...)`, and is not enabled in the default cipher preference list yet.
+`chacha20-poly1305@openssh.com` is not supported yet.
 
-Example (opt-in AES-GCM with explicit fallback ciphers):
+**Integrity**: 
+- `hmac-sha2-[256|512]-etm@openssh.com`
+- `hmac-sha2-[256|512]`
+- `hmac-sha2-[256|512]-96`
+- `hmac-sha1`
+- `hmac-md5`
+
+### Default preferences
+
+Each list is ordered by preference and the first algorithm the server also
+supports is the one that gets used. The defaults lead with the strongest
+option and keep the weaker ones only as a fallback for old servers:
+
+| | Default order |
+|---|---|
+| **Key exchange** | curve25519 → ECDH NIST → DH group-exchange/group14 SHA-256 → the SHA-1 variants |
+| **Host key** | `ssh-ed25519` → `rsa-sha2-512/256` → ECDSA → `ssh-rsa` |
+| **Cipher** | AES-GCM → AES-CTR → AES-CBC |
+| **Integrity** | ETM variants → `hmac-sha2-256/512` → `hmac-sha1` |
+
+Three groups are implemented but **left out of the defaults**, because they are
+considered broken rather than merely old. Pass them to `SSHAlgorithms`
+explicitly if a legacy server leaves you no choice:
+
+- `diffie-hellman-group1-sha1`, whose 1024-bit group is below any current recommendation.
+- `hmac-md5`.
+- The truncated `hmac-sha2-[256|512]-96` variants.
 
 ```dart
 void main() async {
@@ -714,14 +776,8 @@ void main() async {
     username: '<username>',
     onPasswordRequest: () => '<password>',
     algorithms: const SSHAlgorithms(
-      cipher: [
-        SSHCipherType.aes256gcm,
-        SSHCipherType.aes128gcm,
-        SSHCipherType.aes256ctr,
-        SSHCipherType.aes128ctr,
-        SSHCipherType.aes256cbc,
-        SSHCipherType.aes128cbc,
-      ],
+      // Only do this for a server that supports nothing better.
+      kex: [SSHKexType.dh14Sha1, SSHKexType.dh1Sha1],
     ),
   );
 
@@ -730,12 +786,10 @@ void main() async {
 }
 ```
 
-`chacha20-poly1305@openssh.com` is not supported yet.
+### Protocol hardening
 
-**Integrity**: 
-- `hmac-md5`
-- `hmac-sha1`
-- `hmac-sha2-[256|512]`
+- **Strict key exchange** (`kex-strict-c-v00@openssh.com`) is negotiated automatically and enabled whenever the server supports it. It is the countermeasure against the Terrapin attack ([CVE-2023-48795](https://terrapin-attack.com)): packet sequence numbers are reset after every `SSH_MSG_NEWKEYS`, and the optional `SSH_MSG_IGNORE` / `SSH_MSG_UNIMPLEMENTED` / `SSH_MSG_DEBUG` messages are rejected while a key exchange is running. `SSHClient.strictKex` reports whether it is active on a live connection.
+- **EXT_INFO** ([RFC 8308](https://datatracker.ietf.org/doc/html/rfc8308)) is requested via `ext-info-c`. The signature algorithms the server advertises are exposed as `SSHClient.serverSigAlgs`.
 
 **Private key**:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,54 @@
 # Security Policy
 
-## Supported Versions
+dartssh2 is an SSH and SFTP client. A defect in it can expose credentials,
+session contents, or transferred files, so security reports get priority over
+everything else in the issue tracker.
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+## Supported versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+Security fixes are released for the latest published version on
+[pub.dev](https://pub.dev/packages/dartssh2). Older majors are not patched, so
+upgrading is part of the fix.
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
-Use this section to tell people how to report a vulnerability.
+**Do not open a public issue for a vulnerability.**
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Report it through
+[GitHub private vulnerability reporting](https://github.com/vicajilau/dartssh2/security/advisories/new),
+which keeps the discussion private until a fix is published.
+
+A useful report includes:
+
+- The version of dartssh2 and of the Dart SDK.
+- What an attacker gains, and what position they need to be in (network
+  attacker, malicious server, local user).
+- A reproduction: a short Dart program, the server involved, or a packet
+  capture.
+
+You can expect an acknowledgement within a week. Once a fix is ready it is
+published to pub.dev together with an advisory crediting you, unless you
+prefer otherwise.
+
+## What is in scope
+
+Anything that lets an attacker read or alter a session they should not be able
+to: flaws in key exchange, host key verification, authentication, packet
+parsing, or the SFTP layer.
+
+Two behaviours are documented rather than defects:
+
+- **Host key identity is not checked unless you check it.** The signature on
+  the host key is always verified, but deciding whether that key is the one you
+  expected is the caller's job, through `onVerifyHostKey`. A client that omits
+  the handler accepts any host key. See
+  [Verify the host key](README.md#verify-the-host-key).
+- **Weak algorithms are still implemented.** `diffie-hellman-group1-sha1`,
+  `hmac-md5`, the truncated `hmac-sha2-*-96` variants, and CBC ciphers exist so
+  that old servers remain reachable. The broken ones are not in the default
+  preference lists and are only used when passed to `SSHAlgorithms`
+  explicitly.
+
+Reports that only point out that these options exist are not treated as
+vulnerabilities. A report showing that a default configuration selects one of
+them unexpectedly is.

--- a/lib/src/message/msg_ext_info.dart
+++ b/lib/src/message/msg_ext_info.dart
@@ -1,0 +1,67 @@
+// ignore_for_file: camel_case_types
+
+import 'dart:typed_data';
+
+import 'package:dartssh2/src/ssh_message.dart';
+
+/// SSH_MSG_EXT_INFO as defined in RFC 8308 §2.3.
+///
+/// Sent by a peer that saw the `ext-info-c` (client) or `ext-info-s` (server)
+/// indicator in the other side's SSH_MSG_KEXINIT. It carries a list of
+/// extension name/value pairs, of which `server-sig-algs` (RFC 8308 §3.1) is
+/// the one clients care about most: it tells the client which public key
+/// signature algorithms the server will accept during user authentication.
+class SSH_Message_ExtInfo extends SSHMessage {
+  static const messageId = 7;
+
+  /// The extensions sent by the peer, keyed by extension name.
+  ///
+  /// Values are kept as raw bytes because RFC 8308 does not require them to be
+  /// UTF-8. Use [serverSigAlgs] for the one extension this client interprets.
+  final Map<String, Uint8List> extensions;
+
+  SSH_Message_ExtInfo(this.extensions);
+
+  factory SSH_Message_ExtInfo.decode(Uint8List bytes) {
+    final reader = SSHMessageReader(bytes);
+    reader.skip(1);
+    final count = reader.readUint32();
+    final extensions = <String, Uint8List>{};
+    for (var i = 0; i < count; i++) {
+      // A truncated or lying count must not take the connection down: RFC 8308
+      // §2.5 requires unrecognised or malformed extensions to be ignored.
+      if (reader.isDone) break;
+      final name = reader.readUtf8(allowMalformed: true);
+      if (reader.isDone) break;
+      extensions[name] = reader.readString();
+    }
+    return SSH_Message_ExtInfo(extensions);
+  }
+
+  /// The signature algorithms the server accepts for `publickey`
+  /// authentication, or `null` if the server did not send the extension.
+  List<String>? get serverSigAlgs {
+    final value = extensions['server-sig-algs'];
+    if (value == null) return null;
+    final names = String.fromCharCodes(value);
+    if (names.isEmpty) return const [];
+    return names.split(',');
+  }
+
+  @override
+  Uint8List encode() {
+    final writer = SSHMessageWriter();
+    writer.writeUint8(messageId);
+    writer.writeUint32(extensions.length);
+    for (final entry in extensions.entries) {
+      writer.writeUtf8(entry.key);
+      writer.writeString(entry.value);
+    }
+    return writer.takeBytes();
+  }
+
+  @override
+  String toString() {
+    return 'SSH_Message_ExtInfo(extensions: ${extensions.keys.toList()})';
+  }
+}

--- a/lib/src/message/msg_userauth.dart
+++ b/lib/src/message/msg_userauth.dart
@@ -121,32 +121,36 @@ class SSH_Message_Userauth_Request extends SSHMessage {
     switch (methodName) {
       case 'password':
         final hasNewPassword = reader.readBool();
-        final password = reader.readUtf8();
         if (hasNewPassword) {
+          // RFC 4252 §8 puts the old password on the wire first, then the new
+          // one.
           final oldPassword = reader.readUtf8();
+          final newPassword = reader.readUtf8();
           return SSH_Message_Userauth_Request.newPassword(
             user: user,
             oldPassword: oldPassword,
-            newPassword: password,
+            newPassword: newPassword,
             serviceName: serviceName,
           );
         } else {
           return SSH_Message_Userauth_Request.password(
             user: user,
-            password: password,
+            password: reader.readUtf8(),
             serviceName: serviceName,
           );
         }
       case 'publickey':
+        // RFC 4252 §7: the boolean says whether a signature follows the public
+        // key, and it precedes the algorithm name.
+        final hasSignature = reader.readBool();
         final publicKeyAlgorithm = reader.readUtf8();
         final publicKey = reader.readString();
-        final signature = reader.readString();
         return SSH_Message_Userauth_Request.publicKey(
           username: user,
           serviceName: serviceName,
           publicKeyAlgorithm: publicKeyAlgorithm,
           publicKey: publicKey,
-          signature: signature,
+          signature: hasSignature ? reader.readString() : null,
         );
       case 'keyboard-interactive':
         final languageTag = reader.readUtf8();

--- a/lib/src/ssh_algorithm.dart
+++ b/lib/src/ssh_algorithm.dart
@@ -43,6 +43,17 @@ class SSHAlgorithms {
   /// Algorithm used for the authentication.
   final List<SSHMacType> mac;
 
+  /// Creates an algorithm preference set.
+  ///
+  /// Every list is ordered by preference: the first entry that the peer also
+  /// supports is the one that gets negotiated (RFC 4253 §7.1). The defaults
+  /// put the strongest algorithm first and keep weaker ones only as a
+  /// last-resort fallback for old servers.
+  ///
+  /// Algorithms considered broken are not in the defaults at all, but they are
+  /// still implemented and can be re-enabled explicitly. `diffie-hellman-
+  /// group1-sha1` (1024-bit DH), `hmac-md5`, and the truncated
+  /// `hmac-sha2-[256|512]-96` variants fall in that group.
   const SSHAlgorithms({
     this.kex = const [
       SSHKexType.x25519Rfc,
@@ -52,34 +63,38 @@ class SSHAlgorithms {
       SSHKexType.nistp256,
       SSHKexType.dhGexSha256,
       SSHKexType.dh14Sha256,
+      // SHA-1 based key exchange is kept last for old servers only.
       SSHKexType.dh14Sha1,
       SSHKexType.dhGexSha1,
-      SSHKexType.dh1Sha1,
     ],
     this.hostkey = const [
       SSHHostkeyType.ed25519,
       SSHHostkeyType.rsaSha512,
       SSHHostkeyType.rsaSha256,
-      SSHHostkeyType.rsaSha1,
       SSHHostkeyType.ecdsa521,
       SSHHostkeyType.ecdsa384,
       SSHHostkeyType.ecdsa256,
+      // `ssh-rsa` signs with SHA-1. OpenSSH disabled it by default in 8.8, so
+      // it is only reached when the server offers nothing better.
+      SSHHostkeyType.rsaSha1,
     ],
     this.cipher = const [
-      SSHCipherType.aes128ctr,
-      SSHCipherType.aes128cbc,
+      SSHCipherType.aes256gcm,
+      SSHCipherType.aes128gcm,
       SSHCipherType.aes256ctr,
+      SSHCipherType.aes128ctr,
+      // CBC in SSH is vulnerable to the plaintext-recovery attack described in
+      // CVE-2008-5161. Kept last so it is only used when nothing else matches.
       SSHCipherType.aes256cbc,
+      SSHCipherType.aes128cbc,
     ],
     this.mac = const [
-      SSHMacType.hmacSha256_96,
-      SSHMacType.hmacSha512_96,
+      // Encrypt-then-MAC is preferred over the encrypt-and-MAC variants.
       SSHMacType.hmacSha256Etm,
       SSHMacType.hmacSha512Etm,
-      SSHMacType.hmacSha1,
       SSHMacType.hmacSha256,
       SSHMacType.hmacSha512,
-      SSHMacType.hmacMd5,
+      SSHMacType.hmacSha1,
     ],
   });
 }

--- a/lib/src/ssh_client.dart
+++ b/lib/src/ssh_client.dart
@@ -325,6 +325,23 @@ class SSHClient {
   /// completed.
   String? get remoteVersion => _transport.remoteVersion;
 
+  /// Whether strict key exchange is in effect for this connection.
+  ///
+  /// It is negotiated automatically and requires the server to support it too.
+  /// Strict key exchange is the countermeasure against the Terrapin attack
+  /// (CVE-2023-48795), so a `false` here on an untrusted network means the
+  /// connection is only as safe as the negotiated cipher makes it.
+  ///
+  /// Meaningless before the first key exchange completes.
+  bool get strictKex => _transport.strictKex;
+
+  /// The signature algorithms the server accepts for `publickey`
+  /// authentication, taken from the `server-sig-algs` extension of
+  /// SSH_MSG_EXT_INFO (RFC 8308 §3.1).
+  ///
+  /// `null` when the server sent no EXT_INFO or omitted the extension.
+  List<String>? get serverSigAlgs => _transport.serverSigAlgs;
+
   /// Request connections to a port on the other side be forwarded to the local
   /// side.
   /// Set [host] to null to listen on all interfaces, `"0.0.0.0"` to

--- a/lib/src/ssh_packet.dart
+++ b/lib/src/ssh_packet.dart
@@ -69,4 +69,13 @@ class SSHPacketSN {
       _value++;
     }
   }
+
+  /// Resets the sequence number back to zero.
+  ///
+  /// Used by the strict key exchange mode, which resets both sequence numbers
+  /// after every SSH_MSG_NEWKEYS instead of letting them run monotonically for
+  /// the whole session.
+  void reset() {
+    _value = 0;
+  }
 }

--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -19,6 +19,7 @@ import 'package:dartssh2/src/ssh_packet.dart';
 import 'package:dartssh2/src/utils/int.dart';
 import 'package:dartssh2/src/hostkey/hostkey_ed25519.dart';
 import 'package:dartssh2/src/utils/list.dart';
+import 'package:dartssh2/src/message/msg_ext_info.dart';
 import 'package:dartssh2/src/message/msg_kex.dart';
 import 'package:dartssh2/src/message/msg_kex_dh.dart';
 import 'package:dartssh2/src/message/msg_kex_ecdh.dart';
@@ -47,6 +48,22 @@ Uint8List _hostkeyFingerprint(Uint8List hostkey) {
 typedef SSHTransportReadyHandler = void Function();
 
 typedef SSHPacketHandler = void Function(Uint8List payload);
+
+/// Pseudo algorithm names that are advertised inside the key exchange
+/// name-list without being key exchange algorithms themselves.
+abstract class SSHKexPseudoAlgorithm {
+  /// Sent by a client to signal support for strict key exchange.
+  static const strictKexClient = 'kex-strict-c-v00@openssh.com';
+
+  /// Sent by a server to signal support for strict key exchange.
+  static const strictKexServer = 'kex-strict-s-v00@openssh.com';
+
+  /// Sent by a client to ask for SSH_MSG_EXT_INFO (RFC 8308 §2.2).
+  static const extInfoClient = 'ext-info-c';
+
+  /// Sent by a server to ask for SSH_MSG_EXT_INFO (RFC 8308 §2.2).
+  static const extInfoServer = 'ext-info-s';
+}
 
 class SSHTransport {
   /// Version of the SSH software. By default "DartSSH_2.0"
@@ -246,6 +263,38 @@ class SSHTransport {
   /// Whether we have already sent our SSH_MSG_KEXINIT for the ongoing key
   /// exchange round. This is reset when the exchange finishes.
   bool _sentKexInit = false;
+
+  /// Whether the initial key exchange is still running. The strict key exchange
+  /// and EXT_INFO indicators are only valid in the first SSH_MSG_KEXINIT, so
+  /// they are advertised and read while this is `true`.
+  bool _isFirstKex = true;
+
+  /// Whether both peers advertised strict key exchange and it is therefore in
+  /// effect for this connection.
+  ///
+  /// Strict key exchange is the countermeasure against the Terrapin attack
+  /// (CVE-2023-48795). It removes the attacker's ability to delete packets
+  /// from the start of the connection undetected, by resetting the packet
+  /// sequence numbers after every SSH_MSG_NEWKEYS and by forbidding the
+  /// optional messages that made the injection possible.
+  bool get strictKex => _strictKex;
+  var _strictKex = false;
+
+  /// Set when a received SSH_MSG_NEWKEYS asks for a sequence number reset, so
+  /// that the reset happens after [_processPackets] is done with the packet
+  /// rather than being undone by the trailing increment.
+  var _resetRemotePacketSN = false;
+
+  /// Extensions sent by the server in SSH_MSG_EXT_INFO (RFC 8308), or `null`
+  /// if the server sent none.
+  Map<String, Uint8List>? get extInfo => _extInfo;
+  Map<String, Uint8List>? _extInfo;
+
+  /// The signature algorithms the server accepts for `publickey`
+  /// authentication, as advertised through the `server-sig-algs` extension.
+  /// `null` when the server did not send it.
+  List<String>? get serverSigAlgs => _serverSigAlgs;
+  List<String>? _serverSigAlgs;
 
   /// Packets queued during key exchange that will be sent after NEW_KEYS
   final List<Uint8List> _rekeyPendingPackets = [];
@@ -596,7 +645,12 @@ class SSHTransport {
 
       await _handleMessage(payload);
 
-      _remotePacketSN.increase();
+      if (_resetRemotePacketSN) {
+        _resetRemotePacketSN = false;
+        _remotePacketSN.reset();
+      } else {
+        _remotePacketSN.increase();
+      }
     }
   }
 
@@ -1029,8 +1083,7 @@ class SSHTransport {
     _sentKexInit = true;
 
     final message = SSH_Message_KexInit(
-      kexAlgorithms: algorithms.kex.toNameList(),
-      // kexAlgorithms: ['curve25519-sha256'],
+      kexAlgorithms: _localKexAlgorithmNames(),
       serverHostKeyAlgorithms: algorithms.hostkey.toNameList(),
       encryptionClientToServer: algorithms.cipher.toNameList(),
       encryptionServerToClient: algorithms.cipher.toNameList(),
@@ -1046,6 +1099,28 @@ class SSHTransport {
 
     sendPacket(payload);
     printTrace?.call('-> $socket: $message');
+  }
+
+  /// The key exchange name-list we advertise, including the pseudo algorithms
+  /// that signal strict key exchange and EXT_INFO support.
+  ///
+  /// Both indicators are only meaningful in the first SSH_MSG_KEXINIT, so they
+  /// are dropped once the initial key exchange is done. Sending them on a
+  /// re-key would be ignored at best and confusing at worst.
+  List<String> _localKexAlgorithmNames() {
+    final names = algorithms.kex.toNameList();
+    if (!_isFirstKex) return names;
+    names.add(
+      isServer
+          ? SSHKexPseudoAlgorithm.strictKexServer
+          : SSHKexPseudoAlgorithm.strictKexClient,
+    );
+    names.add(
+      isServer
+          ? SSHKexPseudoAlgorithm.extInfoServer
+          : SSHKexPseudoAlgorithm.extInfoClient,
+    );
+    return names;
   }
 
   /// Send diffie-hellman key exchange message. The exact message format depends
@@ -1103,11 +1178,31 @@ class SSHTransport {
     final message = SSH_Message_NewKeys();
     printTrace?.call('-> $socket: $message');
     sendPacket(message.encode());
+
+    // [sendPacket] already advanced the sequence number past NEWKEYS, so under
+    // strict key exchange the reset belongs right here: the next packet we
+    // send is the first one of the new keys and must be number zero.
+    if (_strictKex) {
+      _localPacketSN.reset();
+    }
   }
 
   /// Dispatches the incoming decrypted packet payload to the appropriate message handler.
   Future<void> _handleMessage(Uint8List message) async {
     final messageId = SSHMessage.readMessageId(message);
+
+    // Under strict key exchange the optional transport messages are not
+    // allowed to appear between KEXINIT and NEWKEYS. Receiving one there means
+    // someone is padding the transcript, so the connection is torn down.
+    if (_strictKex &&
+        _kexInProgress &&
+        _isForbiddenDuringStrictKex(messageId)) {
+      throw SSHHandshakeError(
+        'Strict key exchange violation: message $messageId received during '
+        'key exchange',
+      );
+    }
+
     switch (messageId) {
       case SSH_Message_KexInit.messageId:
         return _handleMessageKexInit(message);
@@ -1116,9 +1211,57 @@ class SSHTransport {
         return _handleMessageKexReply(message);
       case SSH_Message_NewKeys.messageId:
         return _handleMessageNewKeys(message);
+      case SSH_Message_ExtInfo.messageId:
+        return _handleMessageExtInfo(message);
       default:
         onPacket?.call(message);
     }
+  }
+
+  /// Records the extensions advertised by the peer in SSH_MSG_EXT_INFO.
+  void _handleMessageExtInfo(Uint8List payload) {
+    final message = SSH_Message_ExtInfo.decode(payload);
+    printDebug?.call('SSHTransport._handleMessageExtInfo');
+    printTrace?.call('<- $socket: $message');
+
+    _extInfo = message.extensions;
+    _serverSigAlgs = message.serverSigAlgs;
+  }
+
+  /// Enables strict key exchange when the peer advertised it in its first
+  /// SSH_MSG_KEXINIT, and validates the preconditions the mode requires.
+  ///
+  /// Strict key exchange is the Terrapin (CVE-2023-48795) countermeasure. Once
+  /// both sides have advertised it, the first SSH_MSG_KEXINIT must be the very
+  /// first packet of the connection: if it is not, packets were inserted or
+  /// removed before it and the exchange hash no longer covers the real
+  /// transcript.
+  void _negotiateStrictKex(SSH_Message_KexInit message) {
+    final peerIndicator = isServer
+        ? SSHKexPseudoAlgorithm.strictKexClient
+        : SSHKexPseudoAlgorithm.strictKexServer;
+
+    _strictKex = message.kexAlgorithms.contains(peerIndicator);
+    printDebug?.call('SSHTransport._strictKex = $_strictKex');
+
+    if (!_strictKex) return;
+
+    if (_remotePacketSN.value != 0) {
+      throw SSHHandshakeError(
+        'Strict key exchange violation: KEXINIT was not the first packet '
+        '(sequence number ${_remotePacketSN.value})',
+      );
+    }
+  }
+
+  /// Whether [messageId] is one of the optional transport messages that strict
+  /// key exchange forbids while a key exchange is running.
+  ///
+  /// SSH_MSG_IGNORE (2), SSH_MSG_UNIMPLEMENTED (3) and SSH_MSG_DEBUG (4) carry
+  /// no meaning for the exchange but do advance the sequence numbers, which is
+  /// exactly what the Terrapin attack abuses.
+  static bool _isForbiddenDuringStrictKex(int messageId) {
+    return messageId >= 2 && messageId <= 4;
   }
 
   /// Processes the KEXINIT message received from the remote peer and negotiates algorithms.
@@ -1140,6 +1283,10 @@ class SSHTransport {
     final message = SSH_Message_KexInit.decode(payload);
     printTrace?.call('<- $socket: $message');
     _remoteKexInit = payload;
+
+    if (_isFirstKex) {
+      _negotiateStrictKex(message);
+    }
 
     _kexType = SSHKexUtils.selectAlgorithm(
       localAlgorithms: algorithms.kex,
@@ -1360,7 +1507,15 @@ class SSHTransport {
     // Key exchange round finished.
     _kexInProgress = false;
     _sentKexInit = false;
+    _isFirstKex = false;
     _kex = null;
+
+    // The reset is deferred to [_processPackets]: this handler runs before the
+    // trailing increment for the NEWKEYS packet, so resetting here would be
+    // undone immediately.
+    if (_strictKex) {
+      _resetRemotePacketSN = true;
+    }
 
     // Flush any pending packets
     final pending = List<Uint8List>.from(_rekeyPendingPackets);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartssh2
-version: 3.0.2
+version: 3.1.0
 description: SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as easy to use.
 homepage: https://github.com/vicajilau/dartssh2
 repository: https://github.com/vicajilau/dartssh2

--- a/test/src/algorithm/ssh_cipher_type_test.dart
+++ b/test/src/algorithm/ssh_cipher_type_test.dart
@@ -114,7 +114,6 @@ void main() {
           SSHKexType.dh14Sha256,
           SSHKexType.dh14Sha1,
           SSHKexType.dhGexSha1,
-          SSHKexType.dh1Sha1,
         ]));
 
     expect(
@@ -123,33 +122,66 @@ void main() {
           SSHHostkeyType.ed25519,
           SSHHostkeyType.rsaSha512,
           SSHHostkeyType.rsaSha256,
-          SSHHostkeyType.rsaSha1,
           SSHHostkeyType.ecdsa521,
           SSHHostkeyType.ecdsa384,
           SSHHostkeyType.ecdsa256,
+          SSHHostkeyType.rsaSha1,
         ]));
 
     expect(
         algorithms.cipher,
         equals([
-          SSHCipherType.aes128ctr,
-          SSHCipherType.aes128cbc,
+          SSHCipherType.aes256gcm,
+          SSHCipherType.aes128gcm,
           SSHCipherType.aes256ctr,
+          SSHCipherType.aes128ctr,
           SSHCipherType.aes256cbc,
+          SSHCipherType.aes128cbc,
         ]));
 
     expect(
         algorithms.mac,
         equals([
-          SSHMacType.hmacSha256_96,
-          SSHMacType.hmacSha512_96,
           SSHMacType.hmacSha256Etm,
           SSHMacType.hmacSha512Etm,
-          SSHMacType.hmacSha1,
           SSHMacType.hmacSha256,
           SSHMacType.hmacSha512,
-          SSHMacType.hmacMd5,
+          SSHMacType.hmacSha1,
         ]));
+  });
+
+  group('Default algorithm preferences', () {
+    final algorithms = SSHAlgorithms();
+
+    test('prefer AEAD over CTR, and CTR over CBC', () {
+      final names = algorithms.cipher.toNameList();
+      final firstCbc = names.indexWhere((name) => name.endsWith('-cbc'));
+      final lastCtr = names.lastIndexWhere((name) => name.endsWith('-ctr'));
+      final lastGcm = names.lastIndexWhere((name) => name.contains('gcm'));
+
+      expect(lastGcm, lessThan(lastCtr));
+      expect(lastCtr, lessThan(firstCbc));
+    });
+
+    test('prefer encrypt-then-MAC over encrypt-and-MAC', () {
+      final macs = algorithms.mac;
+      final lastEtm = macs.lastIndexWhere((mac) => mac.isEtm);
+      final firstPlain = macs.indexWhere((mac) => !mac.isEtm);
+
+      expect(lastEtm, lessThan(firstPlain));
+    });
+
+    test('exclude broken algorithms', () {
+      expect(algorithms.mac, isNot(contains(SSHMacType.hmacMd5)));
+      expect(algorithms.mac, isNot(contains(SSHMacType.hmacSha256_96)));
+      expect(algorithms.mac, isNot(contains(SSHMacType.hmacSha512_96)));
+      expect(algorithms.kex, isNot(contains(SSHKexType.dh1Sha1)));
+    });
+
+    test('keep SHA-1 based algorithms last as a fallback', () {
+      expect(algorithms.mac.last, SSHMacType.hmacSha1);
+      expect(algorithms.hostkey.last, SSHHostkeyType.rsaSha1);
+    });
   });
 }
 

--- a/test/src/hostkey/hostkey_verify_test.dart
+++ b/test/src/hostkey/hostkey_verify_test.dart
@@ -1,0 +1,194 @@
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:dartssh2/src/hostkey/hostkey_ecdsa.dart';
+import 'package:dartssh2/src/hostkey/hostkey_rsa.dart';
+import 'package:test/test.dart';
+
+import '../../test_utils.dart';
+
+/// Signs with the private half of a fixture key and verifies with the public
+/// half, which is the path the transport takes for every host key signature.
+void main() {
+  final message = Uint8List.fromList(
+    List.generate(64, (index) => (index * 7) % 256),
+  );
+
+  group('SSHRsaPublicKey.verify', () {
+    late OpenSSHRsaKeyPair keyPair;
+    late SSHRsaPublicKey publicKey;
+
+    setUp(() {
+      keyPair = SSHKeyPair.fromPem(fixture('ssh-rsa/id_rsa.openssh')).single
+          as OpenSSHRsaKeyPair;
+      publicKey = keyPair.toPublicKey() as SSHRsaPublicKey;
+    });
+
+    test('accepts a genuine rsa-sha2-256 signature', () {
+      final signature = keyPair.sign(message);
+
+      expect(signature.type, SSHRsaSignatureType.sha256);
+      expect(publicKey.verify(message, signature), isTrue);
+    });
+
+    test('rejects a signature over different data', () {
+      final signature = keyPair.sign(message);
+      final otherMessage = Uint8List.fromList(message)..[0] ^= 0xff;
+
+      expect(publicKey.verify(otherMessage, signature), isFalse);
+    });
+
+    test('rejects a tampered signature', () {
+      final signature = keyPair.sign(message);
+      final tampered = SSHRsaSignature(
+        signature.type,
+        Uint8List.fromList(signature.signature)..[0] ^= 0x01,
+      );
+
+      expect(publicKey.verify(message, tampered), isFalse);
+    });
+
+    test('rejects a signature verified under the wrong hash', () {
+      // Relabelling an rsa-sha2-256 signature as SHA-1 or SHA-512 must not
+      // verify: the digest OID is part of what is signed.
+      final signature = keyPair.sign(message);
+
+      for (final type in [
+        SSHRsaSignatureType.sha1,
+        SSHRsaSignatureType.sha512,
+      ]) {
+        final relabelled = SSHRsaSignature(type, signature.signature);
+        expect(publicKey.verify(message, relabelled), isFalse);
+      }
+    });
+
+    test('throws on an unknown signature type', () {
+      final signature = SSHRsaSignature('rsa-sha2-999', Uint8List(32));
+
+      expect(
+        () => publicKey.verify(message, signature),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('encodes and decodes the public key', () {
+      final decoded = SSHRsaPublicKey.decode(publicKey.encode());
+
+      expect(decoded.e, publicKey.e);
+      expect(decoded.n, publicKey.n);
+      expect(decoded.toString(), contains('SSHRsaKey'));
+    });
+
+    test('decode rejects a key of the wrong type', () {
+      final wrongType = SSHEcdsaPublicKey(
+        type: 'ecdsa-sha2-nistp256',
+        curveId: 'nistp256',
+        q: Uint8List(1),
+      ).encode();
+
+      expect(() => SSHRsaPublicKey.decode(wrongType), throwsException);
+    });
+
+    test('signature encodes and decodes', () {
+      final signature = keyPair.sign(message);
+      final decoded = SSHRsaSignature.decode(signature.encode());
+
+      expect(decoded.type, signature.type);
+      expect(decoded.signature, signature.signature);
+      expect(decoded.toString(), contains('SSHRsaSignature'));
+    });
+  });
+
+  group('SSHEcdsaPublicKey.verify', () {
+    for (final curve in ['nistp256', 'nistp384', 'nistp521']) {
+      group(curve, () {
+        late OpenSSHEcdsaKeyPair keyPair;
+        late SSHEcdsaPublicKey publicKey;
+
+        setUp(() {
+          keyPair = SSHKeyPair.fromPem(fixture('ecdsa-sha2-$curve/id_ecdsa'))
+              .single as OpenSSHEcdsaKeyPair;
+          publicKey = keyPair.toPublicKey() as SSHEcdsaPublicKey;
+        });
+
+        test('accepts a genuine signature', () {
+          final signature = keyPair.sign(message);
+
+          expect(signature.type, 'ecdsa-sha2-$curve');
+          expect(publicKey.verify(message, signature), isTrue);
+        });
+
+        test('rejects a signature over different data', () {
+          final signature = keyPair.sign(message);
+          final otherMessage = Uint8List.fromList(message)..[1] ^= 0xff;
+
+          expect(publicKey.verify(otherMessage, signature), isFalse);
+        });
+
+        test('rejects a signature with a mangled scalar', () {
+          final signature = keyPair.sign(message);
+          final mangled = SSHEcdsaSignature(
+            signature.type,
+            signature.r + BigInt.one,
+            signature.s,
+          );
+
+          expect(publicKey.verify(message, mangled), isFalse);
+        });
+
+        test('signature encodes and decodes', () {
+          final signature = keyPair.sign(message);
+          final decoded = SSHEcdsaSignature.decode(signature.encode());
+
+          expect(decoded.type, signature.type);
+          expect(decoded.r, signature.r);
+          expect(decoded.s, signature.s);
+          expect(decoded.toString(), contains(curve));
+        });
+
+        test('public key encodes and decodes', () {
+          final decoded = SSHEcdsaPublicKey.decode(publicKey.encode());
+
+          expect(decoded.type, publicKey.type);
+          expect(decoded.curveId, curve);
+          expect(decoded.q, publicKey.q);
+          expect(decoded.toString(), contains(curve));
+        });
+
+        test('selects the matching curve and hash', () {
+          expect(publicKey.curve.domainName, isNotEmpty);
+          expect(
+            publicKey.curveHash.digestSize,
+            {'nistp256': 32, 'nistp384': 48, 'nistp521': 64}[curve],
+          );
+        });
+      });
+    }
+
+    test('decode rejects a key of the wrong type', () {
+      final wrongType = SSHRsaPublicKey(BigInt.two, BigInt.from(9)).encode();
+
+      expect(() => SSHEcdsaPublicKey.decode(wrongType), throwsException);
+    });
+
+    test('decode rejects a signature of the wrong type', () {
+      final wrongType = SSHRsaSignature('ssh-rsa', Uint8List(4)).encode();
+
+      expect(
+        () => SSHEcdsaSignature.decode(wrongType),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('throws on an unsupported curve', () {
+      final key = SSHEcdsaPublicKey(
+        type: 'ecdsa-sha2-nistp192',
+        curveId: 'nistp192',
+        q: Uint8List(1),
+      );
+
+      expect(() => key.curve, throwsException);
+      expect(() => key.curveHash, throwsException);
+    });
+  });
+}

--- a/test/src/message/msg_kex_dh_test.dart
+++ b/test/src/message/msg_kex_dh_test.dart
@@ -1,0 +1,176 @@
+import 'dart:typed_data';
+
+import 'package:dartssh2/src/message/msg_kex_dh.dart';
+import 'package:dartssh2/src/ssh_message.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // A value wide enough to need several bytes and to exercise the mpint sign
+  // handling, which pads values whose top bit is set.
+  final big = BigInt.parse('9' * 60);
+  final highBit = BigInt.parse('ff112233445566778899', radix: 16);
+  final hostKey = Uint8List.fromList(List.generate(48, (i) => i));
+  final signature = Uint8List.fromList(List.generate(72, (i) => 255 - i));
+
+  group('SSH_Message_KexDH_Init', () {
+    test('round-trips', () {
+      final original = SSH_Message_KexDH_Init(e: big);
+      final decoded = SSH_Message_KexDH_Init.decode(original.encode());
+
+      expect(decoded.e, big);
+      expect(original.toString(), contains('SSH_Message_KexDH_Init'));
+    });
+
+    test('carries the right message id', () {
+      final encoded = SSH_Message_KexDH_Init(e: BigInt.one).encode();
+
+      expect(SSHMessage.readMessageId(encoded), 30);
+    });
+
+    test('preserves a value whose top bit is set', () {
+      final original = SSH_Message_KexDH_Init(e: highBit);
+
+      expect(SSH_Message_KexDH_Init.decode(original.encode()).e, highBit);
+    });
+  });
+
+  group('SSH_Message_KexDH_Reply', () {
+    test('round-trips', () {
+      final original = SSH_Message_KexDH_Reply(
+        hostPublicKey: hostKey,
+        f: big,
+        signature: signature,
+      );
+      final decoded = SSH_Message_KexDH_Reply.decode(original.encode());
+
+      expect(decoded.hostPublicKey, hostKey);
+      expect(decoded.f, big);
+      expect(decoded.signature, signature);
+      expect(original.toString(), contains('SSH_Message_KexDH_Reply'));
+    });
+
+    test('carries the right message id', () {
+      final encoded = SSH_Message_KexDH_Reply(
+        hostPublicKey: hostKey,
+        f: BigInt.one,
+        signature: signature,
+      ).encode();
+
+      expect(SSHMessage.readMessageId(encoded), 31);
+    });
+
+    test('handles empty host key and signature', () {
+      final original = SSH_Message_KexDH_Reply(
+        hostPublicKey: Uint8List(0),
+        f: BigInt.zero,
+        signature: Uint8List(0),
+      );
+      final decoded = SSH_Message_KexDH_Reply.decode(original.encode());
+
+      expect(decoded.hostPublicKey, isEmpty);
+      expect(decoded.signature, isEmpty);
+      expect(decoded.f, BigInt.zero);
+    });
+  });
+
+  group('SSH_Message_KexDH_GexRequest', () {
+    test('round-trips', () {
+      final original = SSH_Message_KexDH_GexRequest(
+        minN: 1024,
+        preferredN: 2048,
+        maxN: 8192,
+      );
+      final decoded = SSH_Message_KexDH_GexRequest.decode(original.encode());
+
+      expect(decoded.minN, 1024);
+      expect(decoded.preferredN, 2048);
+      expect(decoded.maxN, 8192);
+      expect(original.toString(), contains('preferredN: 2048'));
+    });
+
+    test('carries the right message id', () {
+      final encoded = SSH_Message_KexDH_GexRequest(
+        minN: 1,
+        preferredN: 2,
+        maxN: 3,
+      ).encode();
+
+      expect(SSHMessage.readMessageId(encoded), 34);
+    });
+  });
+
+  group('SSH_Message_KexDH_GexGroup', () {
+    test('round-trips', () {
+      final original = SSH_Message_KexDH_GexGroup(p: big, g: BigInt.two);
+      final decoded = SSH_Message_KexDH_GexGroup.decode(original.encode());
+
+      expect(decoded.p, big);
+      expect(decoded.g, BigInt.two);
+      expect(original.toString(), contains('SSH_Message_KexDH_GexGroup'));
+    });
+
+    test('carries the right message id', () {
+      final encoded =
+          SSH_Message_KexDH_GexGroup(p: BigInt.one, g: BigInt.two).encode();
+
+      expect(SSHMessage.readMessageId(encoded), 31);
+    });
+  });
+
+  group('SSH_Message_KexDH_GexInit', () {
+    test('round-trips', () {
+      final original = SSH_Message_KexDH_GexInit(e: big);
+      final decoded = SSH_Message_KexDH_GexInit.decode(original.encode());
+
+      expect(decoded.e, big);
+      expect(original.toString(), contains('e: $big'));
+    });
+
+    test('carries the right message id', () {
+      final encoded = SSH_Message_KexDH_GexInit(e: BigInt.one).encode();
+
+      expect(SSHMessage.readMessageId(encoded), 32);
+    });
+  });
+
+  group('SSH_Message_KexDH_GexReply', () {
+    test('round-trips', () {
+      final original = SSH_Message_KexDH_GexReply(
+        hostPublicKey: hostKey,
+        f: big,
+        signature: signature,
+      );
+      final decoded = SSH_Message_KexDH_GexReply.decode(original.encode());
+
+      expect(decoded.hostPublicKey, hostKey);
+      expect(decoded.f, big);
+      expect(decoded.signature, signature);
+      expect(original.toString(), contains('SSH_Message_KexDH_GexReply'));
+    });
+
+    test('carries a different message id than the plain reply', () {
+      final encoded = SSH_Message_KexDH_GexReply(
+        hostPublicKey: hostKey,
+        f: BigInt.one,
+        signature: signature,
+      ).encode();
+
+      expect(SSHMessage.readMessageId(encoded), 33);
+      expect(SSH_Message_KexDH_GexReply.messageId,
+          isNot(SSH_Message_KexDH_Reply.messageId));
+    });
+
+    test('is usable where a plain reply is expected', () {
+      // The transport handles both replies through the same code path, so the
+      // group-exchange variant must stay assignable to the base type.
+      final SSH_Message_KexDH_Reply reply = SSH_Message_KexDH_GexReply(
+        hostPublicKey: hostKey,
+        f: big,
+        signature: signature,
+      );
+
+      expect(reply.f, big);
+      expect(reply.hostPublicKey, hostKey);
+    });
+  });
+}

--- a/test/src/message/msg_userauth_test.dart
+++ b/test/src/message/msg_userauth_test.dart
@@ -1,0 +1,265 @@
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:dartssh2/src/message/msg_userauth.dart';
+import 'package:dartssh2/src/ssh_message.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final publicKey = Uint8List.fromList(List.generate(32, (i) => i));
+  final signature = Uint8List.fromList(List.generate(64, (i) => 255 - i));
+
+  group('SSH_Message_Userauth_Request', () {
+    test('none round-trips', () {
+      final original = SSH_Message_Userauth_Request.none(user: 'root');
+      final decoded = SSH_Message_Userauth_Request.decode(original.encode());
+
+      expect(SSHMessage.readMessageId(original.encode()), 50);
+      expect(decoded.user, 'root');
+      expect(decoded.methodName, 'none');
+      expect(decoded.serviceName, 'ssh-connection');
+      expect(decoded.toString(), contains('methodName: none'));
+    });
+
+    test('password round-trips', () {
+      final original = SSH_Message_Userauth_Request.password(
+        user: 'demo',
+        password: 'hunter2',
+      );
+      final decoded = SSH_Message_Userauth_Request.decode(original.encode());
+
+      expect(decoded.user, 'demo');
+      expect(decoded.methodName, 'password');
+      expect(decoded.password, 'hunter2');
+      expect(decoded.oldPassword, isNull);
+    });
+
+    test('password change round-trips without swapping the passwords', () {
+      // RFC 4252 §8 sends the old password first and the new one second.
+      final original = SSH_Message_Userauth_Request.newPassword(
+        user: 'demo',
+        oldPassword: 'old-secret',
+        newPassword: 'new-secret',
+      );
+      final decoded = SSH_Message_Userauth_Request.decode(original.encode());
+
+      expect(decoded.oldPassword, 'old-secret');
+      expect(decoded.password, 'new-secret');
+    });
+
+    test('signed publickey round-trips', () {
+      final original = SSH_Message_Userauth_Request.publicKey(
+        username: 'demo',
+        publicKeyAlgorithm: 'ssh-ed25519',
+        publicKey: publicKey,
+        signature: signature,
+      );
+      final decoded = SSH_Message_Userauth_Request.decode(original.encode());
+
+      expect(decoded.publicKeyAlgorithm, 'ssh-ed25519');
+      expect(decoded.publicKey, publicKey);
+      expect(decoded.signature, signature);
+    });
+
+    test('unsigned publickey probe round-trips', () {
+      // The probe of RFC 4252 §7.8 carries no signature, and the boolean in
+      // front of the algorithm name is what says so.
+      final original = SSH_Message_Userauth_Request.publicKey(
+        username: 'demo',
+        publicKeyAlgorithm: 'ssh-ed25519',
+        publicKey: publicKey,
+        signature: null,
+      );
+      final decoded = SSH_Message_Userauth_Request.decode(original.encode());
+
+      expect(decoded.publicKeyAlgorithm, 'ssh-ed25519');
+      expect(decoded.publicKey, publicKey);
+      expect(decoded.signature, isNull);
+    });
+
+    test('keyboard-interactive round-trips', () {
+      final original = SSH_Message_Userauth_Request.keyboardInteractive(
+        user: 'demo',
+        languageTag: 'en-US',
+        submethods: 'pam',
+      );
+      final decoded = SSH_Message_Userauth_Request.decode(original.encode());
+
+      expect(decoded.methodName, 'keyboard-interactive');
+      expect(decoded.languageTag, 'en-US');
+      expect(decoded.submethods, 'pam');
+    });
+
+    test('rejects an unknown method on encode and decode', () {
+      final unknown = SSH_Message_Userauth_Request(
+        user: 'demo',
+        serviceName: 'ssh-connection',
+        methodName: 'hostbased',
+      );
+
+      expect(unknown.encode, throwsUnimplementedError);
+
+      // Build the same message by hand so decode sees the unknown method.
+      final writer = SSHMessageWriter();
+      writer.writeUint8(SSH_Message_Userauth_Request.messageId);
+      writer.writeUtf8('demo');
+      writer.writeUtf8('ssh-connection');
+      writer.writeUtf8('hostbased');
+
+      expect(
+        () => SSH_Message_Userauth_Request.decode(writer.takeBytes()),
+        throwsUnimplementedError,
+      );
+    });
+  });
+
+  group('SSH_Message_Userauth_Failure', () {
+    test('round-trips', () {
+      final original = SSH_Message_Userauth_Failure(
+        methodsLeft: const ['publickey', 'password'],
+        partialSuccess: true,
+      );
+      final decoded = SSH_Message_Userauth_Failure.decode(original.encode());
+
+      expect(SSHMessage.readMessageId(original.encode()), 51);
+      expect(decoded.methodsLeft, ['publickey', 'password']);
+      expect(decoded.partialSuccess, isTrue);
+      expect(decoded.toString(), contains('partialSuccess: true'));
+    });
+
+    test('defaults partialSuccess to false', () {
+      final original =
+          SSH_Message_Userauth_Failure(methodsLeft: const ['password']);
+
+      expect(
+        SSH_Message_Userauth_Failure.decode(original.encode()).partialSuccess,
+        isFalse,
+      );
+    });
+  });
+
+  group('SSH_Message_Userauth_Success', () {
+    test('round-trips', () {
+      final original = SSH_Message_Userauth_Success();
+      final decoded = SSH_Message_Userauth_Success.decode(original.encode());
+
+      expect(SSHMessage.readMessageId(original.encode()), 52);
+      expect(decoded, isA<SSH_Message_Userauth_Success>());
+      expect(decoded.toString(), 'SSH_Message_Userauth_Success()');
+    });
+  });
+
+  group('SSH_Message_Userauth_Banner', () {
+    test('round-trips', () {
+      final original = SSH_Message_Userauth_Banner(
+        message: 'Authorised users only',
+        language: 'en',
+      );
+      final decoded = SSH_Message_Userauth_Banner.decode(original.encode());
+
+      expect(SSHMessage.readMessageId(original.encode()), 53);
+      expect(decoded.message, 'Authorised users only');
+      expect(decoded.language, 'en');
+      expect(decoded.toString(), contains('Authorised users only'));
+    });
+
+    test('preserves non-ASCII banners', () {
+      final original = SSH_Message_Userauth_Banner(message: 'contraseña 🔐');
+
+      expect(
+        SSH_Message_Userauth_Banner.decode(original.encode()).message,
+        'contraseña 🔐',
+      );
+    });
+  });
+
+  group('SSH_Message_Userauth_Passwd_ChangeReq', () {
+    test('round-trips', () {
+      final original = SSH_Message_Userauth_Passwd_ChangeReq(
+        prompt: 'Your password has expired',
+      );
+      final decoded =
+          SSH_Message_Userauth_Passwd_ChangeReq.decode(original.encode());
+
+      expect(SSHMessage.readMessageId(original.encode()), 60);
+      expect(decoded.prompt, 'Your password has expired');
+      expect(decoded.toString(), contains('expired'));
+    });
+  });
+
+  group('SSH_Message_Userauth_PK_Ok', () {
+    test('round-trips', () {
+      final original = SSH_Message_Userauth_PK_Ok(
+        publicKeyAlgorithm: 'ssh-ed25519',
+        publicKey: publicKey,
+      );
+      final decoded = SSH_Message_Userauth_PK_Ok.decode(original.encode());
+
+      expect(SSHMessage.readMessageId(original.encode()), 60);
+      expect(decoded.publicKeyAlgorithm, 'ssh-ed25519');
+      expect(decoded.publicKey, publicKey);
+      expect(decoded.toString(), contains('ssh-ed25519'));
+    });
+  });
+
+  group('SSH_Message_Userauth_InfoRequest', () {
+    test('round-trips with prompts', () {
+      final original = SSH_Message_Userauth_InfoRequest(
+        name: 'PAM',
+        instruction: 'Enter your credentials',
+        lang: 'en',
+        prompts: [
+          SSHUserInfoPrompt('Password: ', false),
+          SSHUserInfoPrompt('Token: ', true),
+        ],
+      );
+      final decoded =
+          SSH_Message_Userauth_InfoRequest.decode(original.encode());
+
+      expect(SSHMessage.readMessageId(original.encode()), 60);
+      expect(decoded.name, 'PAM');
+      expect(decoded.instruction, 'Enter your credentials');
+      expect(decoded.prompts, hasLength(2));
+      expect(decoded.prompts[0].promptText, 'Password: ');
+      expect(decoded.prompts[0].echo, isFalse);
+      expect(decoded.prompts[1].echo, isTrue);
+      expect(decoded.toString(), contains('PAM'));
+    });
+
+    test('round-trips with no prompts', () {
+      final original = SSH_Message_Userauth_InfoRequest(
+        name: '',
+        instruction: '',
+        lang: '',
+        prompts: const [],
+      );
+
+      expect(
+        SSH_Message_Userauth_InfoRequest.decode(original.encode()).prompts,
+        isEmpty,
+      );
+    });
+  });
+
+  group('SSH_Message_Userauth_InfoResponse', () {
+    test('round-trips', () {
+      final original = SSH_Message_Userauth_InfoResponse(
+        responses: const ['first', 'second'],
+      );
+      final decoded =
+          SSH_Message_Userauth_InfoResponse.decode(original.encode());
+
+      expect(SSHMessage.readMessageId(original.encode()), 61);
+      expect(decoded.responses, ['first', 'second']);
+    });
+
+    test('round-trips with no responses', () {
+      final original = SSH_Message_Userauth_InfoResponse(responses: const []);
+
+      expect(
+        SSH_Message_Userauth_InfoResponse.decode(original.encode()).responses,
+        isEmpty,
+      );
+    });
+  });
+}

--- a/test/src/ssh_transport_strict_kex_test.dart
+++ b/test/src/ssh_transport_strict_kex_test.dart
@@ -1,0 +1,567 @@
+import 'dart:async';
+import 'dart:mirrors';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:dartssh2/src/message/msg_ext_info.dart';
+import 'package:dartssh2/src/message/msg_kex.dart';
+import 'package:dartssh2/src/ssh_packet.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final transportLibrary = reflectClass(SSHTransport).owner as LibraryMirror;
+  final packetLibrary = reflectClass(SSHPacketSN).owner as LibraryMirror;
+
+  Symbol privateSymbol(String name) =>
+      MirrorSystem.getSymbol(name, transportLibrary);
+  Symbol packetPrivateSymbol(String name) =>
+      MirrorSystem.getSymbol(name, packetLibrary);
+
+  void setPrivate(SSHTransport transport, String field, Object? value) {
+    reflect(transport).setField(privateSymbol(field), value);
+  }
+
+  T getPrivate<T>(SSHTransport transport, String field) {
+    return reflect(transport).getField(privateSymbol(field)).reflectee as T;
+  }
+
+  int sequenceValue(SSHTransport transport, String field) {
+    final sequence =
+        reflect(transport).getField(privateSymbol(field)).reflectee;
+    return reflect(sequence).getField(packetPrivateSymbol('_value')).reflectee
+        as int;
+  }
+
+  void setSequenceValue(SSHTransport transport, String field, int value) {
+    final sequence =
+        reflect(transport).getField(privateSymbol(field)).reflectee;
+    reflect(sequence).setField(packetPrivateSymbol('_value'), value);
+  }
+
+  Future<void> invokePrivate(
+    SSHTransport transport,
+    String method,
+    List<Object?> args,
+  ) async {
+    final result = reflect(transport).invoke(privateSymbol(method), args);
+    final value = result.reflectee;
+    if (value is Future) await value;
+  }
+
+  /// Decodes the KEXINIT that the transport wrote to [socket] during the
+  /// handshake, stripping the RFC 4253 packet framing.
+  SSH_Message_KexInit sentKexInit(_CaptureSSHSocket socket) {
+    // The first write is the version banner, the second one is the KEXINIT.
+    final packet = socket.packets[1];
+    final paddingLength = SSHPacket.readPaddingLength(packet);
+    final payload = Uint8List.sublistView(
+      packet,
+      SSHPacket.headerLength,
+      packet.length - paddingLength,
+    );
+    return SSH_Message_KexInit.decode(payload);
+  }
+
+  /// Builds an unencrypted packet carrying [payload], as it would arrive on
+  /// the wire before NEWKEYS.
+  Uint8List clearTextPacket(Uint8List payload) {
+    return SSHPacket.pack(payload, align: SSHPacket.minAlign);
+  }
+
+  SSH_Message_KexInit serverKexInit(
+      {List<String> extraKexAlgorithms = const []}) {
+    return SSH_Message_KexInit(
+      kexAlgorithms: [SSHKexType.x25519.name, ...extraKexAlgorithms],
+      serverHostKeyAlgorithms: [SSHHostkeyType.ed25519.name],
+      encryptionClientToServer: [SSHCipherType.aes128ctr.name],
+      encryptionServerToClient: [SSHCipherType.aes128ctr.name],
+      macClientToServer: [SSHMacType.hmacSha256.name],
+      macServerToClient: [SSHMacType.hmacSha256.name],
+      compressionClientToServer: const ['none'],
+      compressionServerToClient: const ['none'],
+      firstKexPacketFollows: false,
+    );
+  }
+
+  group('Strict key exchange advertisement', () {
+    test('client advertises strict kex and ext-info in the first KEXINIT', () {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      final message = sentKexInit(socket);
+      expect(message.kexAlgorithms, contains('kex-strict-c-v00@openssh.com'));
+      expect(message.kexAlgorithms, contains('ext-info-c'));
+
+      // The indicators must not displace the real algorithms.
+      expect(message.kexAlgorithms.first, SSHKexType.x25519Rfc.name);
+
+      transport.close();
+    });
+
+    test('server advertises the server-side indicators', () {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket, isServer: true);
+
+      // A server only sends its KEXINIT after seeing the peer version, so
+      // trigger it explicitly.
+      reflect(transport).invoke(privateSymbol('_sendKexInit'), const []);
+
+      final packet = socket.packets[1];
+      final paddingLength = SSHPacket.readPaddingLength(packet);
+      final message = SSH_Message_KexInit.decode(
+        Uint8List.sublistView(
+          packet,
+          SSHPacket.headerLength,
+          packet.length - paddingLength,
+        ),
+      );
+
+      expect(message.kexAlgorithms, contains('kex-strict-s-v00@openssh.com'));
+      expect(message.kexAlgorithms, contains('ext-info-s'));
+
+      transport.close();
+    });
+
+    test('indicators are not repeated on a re-key', () {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      // Simulate the initial exchange having finished, so the next
+      // _sendKexInit is a re-key rather than a no-op.
+      setPrivate(transport, '_isFirstKex', false);
+      setPrivate(transport, '_kexInProgress', false);
+      setPrivate(transport, '_sentKexInit', false);
+      socket.packets.clear();
+
+      reflect(transport).invoke(privateSymbol('_sendKexInit'), const []);
+
+      final packet = socket.packets.last;
+      final paddingLength = SSHPacket.readPaddingLength(packet);
+      final message = SSH_Message_KexInit.decode(
+        Uint8List.sublistView(
+          packet,
+          SSHPacket.headerLength,
+          packet.length - paddingLength,
+        ),
+      );
+
+      expect(
+        message.kexAlgorithms,
+        isNot(contains('kex-strict-c-v00@openssh.com')),
+      );
+      expect(message.kexAlgorithms, isNot(contains('ext-info-c')));
+
+      transport.close();
+    });
+  });
+
+  group('Strict key exchange negotiation', () {
+    test('enabled when the server advertises it', () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      setPrivate(transport, '_kexInProgress', true);
+      setPrivate(transport, '_sentKexInit', true);
+
+      await invokePrivate(transport, '_handleMessageKexInit', [
+        serverKexInit(
+          extraKexAlgorithms: const ['kex-strict-s-v00@openssh.com'],
+        ).encode(),
+      ]);
+
+      expect(transport.strictKex, isTrue);
+
+      transport.close();
+    });
+
+    test('stays disabled when the server does not advertise it', () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      setPrivate(transport, '_kexInProgress', true);
+      setPrivate(transport, '_sentKexInit', true);
+
+      await invokePrivate(
+        transport,
+        '_handleMessageKexInit',
+        [serverKexInit().encode()],
+      );
+
+      expect(transport.strictKex, isFalse);
+
+      transport.close();
+    });
+
+    test('the client-side indicator does not enable it on a client', () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      setPrivate(transport, '_kexInProgress', true);
+      setPrivate(transport, '_sentKexInit', true);
+
+      // A client must only accept the server indicator. Echoing back the
+      // client one must not turn the mode on.
+      await invokePrivate(transport, '_handleMessageKexInit', [
+        serverKexInit(
+          extraKexAlgorithms: const ['kex-strict-c-v00@openssh.com'],
+        ).encode(),
+      ]);
+
+      expect(transport.strictKex, isFalse);
+
+      transport.close();
+    });
+
+    test('rejects a first KEXINIT that is not the first packet', () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      setPrivate(transport, '_kexInProgress', true);
+      setPrivate(transport, '_sentKexInit', true);
+      // Something was received before the KEXINIT, which is exactly the
+      // packet-insertion Terrapin relies on.
+      setSequenceValue(transport, '_remotePacketSN', 1);
+
+      await expectLater(
+        invokePrivate(transport, '_handleMessageKexInit', [
+          serverKexInit(
+            extraKexAlgorithms: const ['kex-strict-s-v00@openssh.com'],
+          ).encode(),
+        ]),
+        throwsA(isA<SSHHandshakeError>()),
+      );
+
+      transport.close();
+    });
+  });
+
+  group('Strict key exchange message filtering', () {
+    for (final entry in {
+      'SSH_MSG_IGNORE': 2,
+      'SSH_MSG_UNIMPLEMENTED': 3,
+      'SSH_MSG_DEBUG': 4,
+    }.entries) {
+      test('rejects ${entry.key} during key exchange', () async {
+        final socket = _CaptureSSHSocket();
+        final transport = SSHTransport(socket);
+
+        setPrivate(transport, '_strictKex', true);
+        setPrivate(transport, '_kexInProgress', true);
+
+        await expectLater(
+          invokePrivate(transport, '_handleMessage', [
+            Uint8List.fromList([entry.value, 0, 0, 0, 0])
+          ]),
+          throwsA(isA<SSHHandshakeError>()),
+        );
+
+        transport.close();
+      });
+
+      test('allows ${entry.key} outside of key exchange', () async {
+        final socket = _CaptureSSHSocket();
+        final transport = SSHTransport(socket);
+
+        setPrivate(transport, '_strictKex', true);
+        setPrivate(transport, '_kexInProgress', false);
+
+        await invokePrivate(transport, '_handleMessage', [
+          Uint8List.fromList([entry.value, 0, 0, 0, 0])
+        ]);
+
+        transport.close();
+      });
+
+      test('allows ${entry.key} when strict kex is off', () async {
+        final socket = _CaptureSSHSocket();
+        final transport = SSHTransport(socket);
+
+        setPrivate(transport, '_strictKex', false);
+        setPrivate(transport, '_kexInProgress', true);
+
+        await invokePrivate(transport, '_handleMessage', [
+          Uint8List.fromList([entry.value, 0, 0, 0, 0])
+        ]);
+
+        transport.close();
+      });
+    }
+  });
+
+  group('Strict key exchange sequence numbers', () {
+    /// Prepares the state [_applyRemoteKeys] needs so a NEWKEYS can be handled.
+    void prepareKeys(SSHTransport transport) {
+      setPrivate(transport, '_kexType', SSHKexType.x25519);
+      setPrivate(transport, '_sharedSecret', BigInt.from(42));
+      setPrivate(transport, '_exchangeHash',
+          Uint8List.fromList(List<int>.filled(32, 1)));
+      setPrivate(
+          transport, '_sessionId', Uint8List.fromList(List<int>.filled(32, 2)));
+      setPrivate(transport, '_clientCipherType', SSHCipherType.aes128ctr);
+      setPrivate(transport, '_serverCipherType', SSHCipherType.aes128ctr);
+      setPrivate(transport, '_clientMacType', SSHMacType.hmacSha256);
+      setPrivate(transport, '_serverMacType', SSHMacType.hmacSha256);
+    }
+
+    test('local sequence number resets after sending NEWKEYS', () {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      setPrivate(transport, '_strictKex', true);
+      setSequenceValue(transport, '_localPacketSN', 7);
+
+      reflect(transport).invoke(privateSymbol('_sendNewKeys'), const []);
+
+      expect(sequenceValue(transport, '_localPacketSN'), 0);
+
+      transport.close();
+    });
+
+    test('local sequence number keeps counting without strict kex', () {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      setPrivate(transport, '_strictKex', false);
+      setSequenceValue(transport, '_localPacketSN', 7);
+
+      reflect(transport).invoke(privateSymbol('_sendNewKeys'), const []);
+
+      expect(sequenceValue(transport, '_localPacketSN'), 8);
+
+      transport.close();
+    });
+
+    test('remote sequence number resets after receiving NEWKEYS', () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      prepareKeys(transport);
+      setPrivate(transport, '_strictKex', true);
+      setPrivate(transport, '_remoteVersion', 'SSH-2.0-test');
+      setSequenceValue(transport, '_remotePacketSN', 9);
+
+      final dynamic buffer = getPrivate<dynamic>(transport, '_buffer');
+      buffer.add(clearTextPacket(SSH_Message_NewKeys().encode()));
+
+      await invokePrivate(transport, '_processPackets', const []);
+
+      expect(sequenceValue(transport, '_remotePacketSN'), 0);
+
+      transport.close();
+    });
+
+    test('remote sequence number keeps counting without strict kex', () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      prepareKeys(transport);
+      setPrivate(transport, '_strictKex', false);
+      setPrivate(transport, '_remoteVersion', 'SSH-2.0-test');
+      setSequenceValue(transport, '_remotePacketSN', 9);
+
+      final dynamic buffer = getPrivate<dynamic>(transport, '_buffer');
+      buffer.add(clearTextPacket(SSH_Message_NewKeys().encode()));
+
+      await invokePrivate(transport, '_processPackets', const []);
+
+      expect(sequenceValue(transport, '_remotePacketSN'), 10);
+
+      transport.close();
+    });
+
+    test('the reset applies once, not to every later packet', () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      prepareKeys(transport);
+      setPrivate(transport, '_strictKex', true);
+      setPrivate(transport, '_remoteVersion', 'SSH-2.0-test');
+      setSequenceValue(transport, '_remotePacketSN', 9);
+
+      // NEWKEYS resets to 0, then two ordinary packets take it to 2. They are
+      // read as clear text because the remote keys are only applied to the
+      // cipher once a non-null key is set, which this fixture does not do.
+      final dynamic buffer = getPrivate<dynamic>(transport, '_buffer');
+      buffer.add(clearTextPacket(SSH_Message_NewKeys().encode()));
+
+      await invokePrivate(transport, '_processPackets', const []);
+      expect(sequenceValue(transport, '_remotePacketSN'), 0);
+
+      setPrivate(transport, '_remoteCipherKey', null);
+      setPrivate(transport, '_decryptCipher', null);
+
+      buffer.add(clearTextPacket(Uint8List.fromList([94, 1, 2])));
+      buffer.add(clearTextPacket(Uint8List.fromList([94, 3, 4])));
+
+      await invokePrivate(transport, '_processPackets', const []);
+      expect(sequenceValue(transport, '_remotePacketSN'), 2);
+
+      transport.close();
+    });
+  });
+
+  group('EXT_INFO', () {
+    test('records server-sig-algs sent by the server', () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      final message = SSH_Message_ExtInfo({
+        'server-sig-algs': Uint8List.fromList(
+          'rsa-sha2-512,rsa-sha2-256,ssh-ed25519'.codeUnits,
+        ),
+      });
+
+      await invokePrivate(
+        transport,
+        '_handleMessageExtInfo',
+        [message.encode()],
+      );
+
+      expect(
+        transport.serverSigAlgs,
+        ['rsa-sha2-512', 'rsa-sha2-256', 'ssh-ed25519'],
+      );
+      expect(transport.extInfo, isNotNull);
+      expect(transport.extInfo!.keys, contains('server-sig-algs'));
+
+      transport.close();
+    });
+
+    test('serverSigAlgs is null when the extension is absent', () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      final message = SSH_Message_ExtInfo({
+        'delay-compression': Uint8List.fromList([1, 2, 3]),
+      });
+
+      await invokePrivate(
+        transport,
+        '_handleMessageExtInfo',
+        [message.encode()],
+      );
+
+      expect(transport.serverSigAlgs, isNull);
+      expect(transport.extInfo!.keys, contains('delay-compression'));
+
+      transport.close();
+    });
+
+    test('round-trips through encode and decode', () {
+      final original = SSH_Message_ExtInfo({
+        'server-sig-algs': Uint8List.fromList('rsa-sha2-256'.codeUnits),
+        'delay-compression': Uint8List.fromList([9, 9]),
+      });
+
+      final decoded = SSH_Message_ExtInfo.decode(original.encode());
+
+      expect(decoded.extensions, hasLength(2));
+      expect(decoded.serverSigAlgs, ['rsa-sha2-256']);
+      expect(decoded.extensions['delay-compression'], [9, 9]);
+      expect(decoded.toString(), contains('server-sig-algs'));
+    });
+
+    test('ignores a truncated extension list instead of throwing', () {
+      // A count of 5 with a single extension present must not blow up.
+      final writer = _extInfoWithCount(5, {
+        'server-sig-algs': 'ssh-ed25519',
+      });
+
+      final decoded = SSH_Message_ExtInfo.decode(writer);
+
+      expect(decoded.serverSigAlgs, ['ssh-ed25519']);
+    });
+
+    test('an empty server-sig-algs value decodes to an empty list', () {
+      final message = SSH_Message_ExtInfo({
+        'server-sig-algs': Uint8List(0),
+      });
+
+      final decoded = SSH_Message_ExtInfo.decode(message.encode());
+
+      expect(decoded.serverSigAlgs, isEmpty);
+    });
+  });
+}
+
+/// Builds an SSH_MSG_EXT_INFO body whose declared extension count does not
+/// match the number of extensions actually written.
+Uint8List _extInfoWithCount(int count, Map<String, String> extensions) {
+  final builder = BytesBuilder();
+  builder.addByte(SSH_Message_ExtInfo.messageId);
+  builder.add(_uint32(count));
+  for (final entry in extensions.entries) {
+    builder.add(_uint32(entry.key.length));
+    builder.add(entry.key.codeUnits);
+    builder.add(_uint32(entry.value.length));
+    builder.add(entry.value.codeUnits);
+  }
+  return builder.takeBytes();
+}
+
+List<int> _uint32(int value) {
+  final data = ByteData(4);
+  data.setUint32(0, value);
+  return data.buffer.asUint8List();
+}
+
+class _CaptureSSHSocket implements SSHSocket {
+  final _inputController = StreamController<Uint8List>();
+  final _doneCompleter = Completer<void>();
+  final packets = <Uint8List>[];
+
+  @override
+  Stream<Uint8List> get stream => _inputController.stream;
+
+  @override
+  StreamSink<List<int>> get sink => _CaptureSink(packets);
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  @override
+  Future<void> close() async {
+    if (!_doneCompleter.isCompleted) {
+      _doneCompleter.complete();
+    }
+    await _inputController.close();
+  }
+
+  @override
+  void destroy() {
+    if (!_doneCompleter.isCompleted) {
+      _doneCompleter.complete();
+    }
+    unawaited(_inputController.close());
+  }
+
+  @override
+  Future<void> flush() async {}
+}
+
+class _CaptureSink implements StreamSink<List<int>> {
+  _CaptureSink(this._packets);
+
+  final List<Uint8List> _packets;
+
+  @override
+  void add(List<int> data) {
+    _packets.add(Uint8List.fromList(data));
+  }
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) async {
+    await for (final chunk in stream) {
+      add(chunk);
+    }
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> get done async {}
+}


### PR DESCRIPTION
Five related changes to the security posture of the client, found while reviewing the repository. Each one is a separate commit.

## Strict key exchange (CVE-2023-48795)

The client had no Terrapin countermeasure. `kex-strict-c-v00@openssh.com` is now advertised and enabled whenever the server supports it: sequence numbers reset after every `SSH_MSG_NEWKEYS`, `SSH_MSG_IGNORE` / `SSH_MSG_UNIMPLEMENTED` / `SSH_MSG_DEBUG` are rejected during a key exchange, and the first `KEXINIT` must be the first packet of the connection. Exposed as `SSHClient.strictKex`.

The receive-side reset is deferred to `_processPackets`, because the trailing `_remotePacketSN.increase()` runs after the message handler and would otherwise undo it.

Also adds `SSH_MSG_EXT_INFO` (RFC 8308), with the server's accepted signature algorithms exposed as `SSHClient.serverSigAlgs`.

## Default algorithm preferences

The defaults preferred `aes128-cbc` over `aes256-ctr`, led the MAC list with the truncated 96-bit variants ahead of the ETM ones, and left AES-GCM out entirely although it was implemented and tested.

Now: AES-GCM before CTR before CBC, encrypt-then-MAC before the plain HMACs, and `ssh-rsa` (SHA-1) last among the host key algorithms.

`diffie-hellman-group1-sha1`, `hmac-md5` and the truncated `hmac-sha2-*-96` variants leave the defaults. They stay implemented and can be re-enabled through `SSHAlgorithms`.

**This changes what gets negotiated on existing connections.** Against `test.rebex.net` the negotiation moves from `aes128-ctr` + `hmac-sha2-256-96` to `aes256-gcm@openssh.com` + `hmac-sha2-256-etm@openssh.com`. Servers that only speak CBC or `hmac-sha1` still connect, since both remain in the lists as a fallback.

## Two decoding bugs in userauth

Writing the coverage tests surfaced `SSH_Message_Userauth_Request.encode()` and `decode()` not being inverses:

- A password change request sends the old password first, then the new one (RFC 4252 §8). `decode()` read them the other way round and returned them swapped.
- A `publickey` request carries a boolean before the algorithm name saying whether a signature follows (RFC 4252 §7). `decode()` never consumed it, misaligning every field of a signed request.

Nothing was broken at runtime, since only a peer decoding a request reaches this and the package has no server side. The decoders are public API, though, and are meant to invert the encoders.

## Coverage on the cryptographic paths

Unit coverage goes from 61.9% to 67.5%, concentrated where it was thinnest:

| File | Before | After |
|---|---|---|
| `msg_kex_dh.dart` | 0% | 100% |
| `hostkey_ecdsa.dart` | 22.6% | 100% |
| `hostkey_rsa.dart` | 39.1% | 100% |
| `msg_userauth.dart` | 28.6% | 98.9% |

The host key tests sign with the private half of a fixture key and verify with the public half, covering the negative cases too: signature over different data, tampered signature, signature relabelled with the wrong hash, unsupported curves.

## Documentation

The README never mentioned `onVerifyHostKey`. Signatures are always verified, but deciding whether the key is the expected one is the caller's job, and omitting the handler accepts any host key, so a reader following the quick start had no way to know. Adds a section on it, documents the new defaults and the protocol hardening, and replaces the unedited GitHub `SECURITY.md` template with a real policy.

## Verification

- `dart analyze --fatal-infos` clean, `dart format` clean.
- 418 unit tests and the 23 integration tests pass.
- Strict key exchange verified against a live server (`_strictKex = true` with RebexSSH 8.0). Since AEAD ciphers use their own invocation counter, it was also verified forcing `aes256-ctr` with both ETM and plain HMAC, where the sequence number does feed the MAC: a wrong reset would fail the first packet after NEWKEYS. Both authenticated and ran commands.
- The two decoding fixes were confirmed by running the new tests against the previous code, where three of them fail.

`pubspec.yaml` goes to 3.1.0 because the CHANGELOG needs a version and the defaults changed. Happy to renumber.
