### PR TITLE
ci: restrict workflow permissions and point Dependabot at the manifest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,11 @@
 
 version: 2
 updates:
+  # The package manifest lives at the repository root. /example/ holds loose
+  # .dart files with no pubspec.yaml of their own, so pointing here is what
+  # actually puts asn1lib, pointycastle, pinenacl and convert under watch.
   - package-ecosystem: "pub"
-    directory: "/example/"
+    directory: "/"
     schedule:
       interval: "weekly"
       time: "09:00"

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
 
+# This workflow only reads the repository: it checks out, analyzes, tests, and
+# uploads coverage with a token of its own. The Codecov token comes from
+# secrets rather than from the GITHUB_TOKEN, so read access is all it needs.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Two independent findings from the repository security tab. Both are configuration only, no library code is touched.

## Workflow permissions (code scanning alert 1)

`.github/workflows/dart.yml` declared no `permissions` block, so its `GITHUB_TOKEN` ran with the repository default instead of the minimum.

The workflow only checks out, analyzes, tests and uploads coverage, and the Codecov token comes from `secrets` rather than from the `GITHUB_TOKEN`, so `contents: read` covers everything it does. `publish.yml` was not flagged because it already declares its own block for OIDC.

## Dependabot was watching nothing

The `pub` entry pointed at `/example/`:

```yaml
- package-ecosystem: "pub"
  directory: "/example/"
```

That directory holds loose `.dart` files and has no `pubspec.yaml` of its own. With no manifest to find, the entry did nothing, and the manifest that does exist at the repository root was left unwatched. The absence of dependency PRs read as "everything is current" when it actually meant "nothing is being checked".

Pointing it at `/` puts the real dependencies under version updates: `asn1lib`, `pointycastle`, `pinenacl` and `convert`.

Expect a first PR shortly after merge for `lints`, which is constrained to `>=4.0.0 <6.0.0` while 6.1.0 has been out for a while. It is a dev dependency, so it has no effect on consumers of the package.

There are no open or closed Dependabot alerts, and repository-level security updates were already enabled, so nothing vulnerable was missed. This only restores the weekly version-update PRs.