### PR TITLE
Fix SSH channel window and open state handling

### DIFF
--- a/lib/src/ssh_channel.dart
+++ b/lib/src/ssh_channel.dart
@@ -7,8 +7,11 @@ import 'package:dartssh2/src/ssh_channel_id.dart';
 import 'package:dartssh2/src/ssh_transport.dart';
 import 'package:dartssh2/src/utils/async_queue.dart';
 import 'package:dartssh2/src/message/msg_channel.dart';
+import 'package:dartssh2/src/ssh_errors.dart';
 import 'package:dartssh2/src/ssh_message.dart';
 import 'package:dartssh2/src/utils/stream.dart';
+
+const _maxChannelWindow = 0xffffffff;
 
 /// Handler of channel requests. Return true if the request was handled, false
 /// if the request was not recognized or could not be handled.
@@ -260,7 +263,15 @@ class SSHChannelController {
       throw ArgumentError.value(bytesToAdd, 'bytesToAdd', 'must be positive');
     }
 
-    _remoteWindow += bytesToAdd;
+    final adjustedWindow = _remoteWindow + bytesToAdd;
+    if (adjustedWindow > _maxChannelWindow) {
+      throw SSHStateError(
+        'Remote window overflow on channel $localId: '
+        '$_remoteWindow + $bytesToAdd exceeds $_maxChannelWindow',
+      );
+    }
+
+    _remoteWindow = adjustedWindow;
 
     if (_remoteWindow > 0) {
       _uploadLoop.activate();
@@ -275,13 +286,24 @@ class SSHChannelController {
       return;
     }
 
-    _remoteStream.add(SSHChannelData(data, type: type));
-
-    _localWindow -= data.length;
-    if (_localWindow < 0) {
-      // Maybe we should close the channel here?
+    final dataKind = type == null ? 'data' : 'extended data';
+    if (data.length > localMaximumPacketSize) {
+      throw SSHStateError(
+        'Received channel $dataKind packet of ${data.length} bytes, '
+        'exceeding maximum packet size $localMaximumPacketSize on '
+        'channel $localId',
+      );
     }
 
+    if (data.length > _localWindow) {
+      throw SSHStateError(
+        'Received channel $dataKind packet of ${data.length} bytes, '
+        'exceeding remaining window $_localWindow on channel $localId',
+      );
+    }
+
+    _localWindow -= data.length;
+    _remoteStream.add(SSHChannelData(data, type: type));
     _sendWindowAdjustIfNeeded();
   }
 
@@ -354,9 +376,10 @@ class SSHChannelController {
 
     if (_done.isCompleted) return;
     if (_remoteStream.isPaused) return;
-    if (_localWindow <= 0) return;
 
     final bytesToAdd = localInitialWindowSize - _localWindow;
+    if (bytesToAdd <= 0) return;
+
     _localWindow = localInitialWindowSize;
 
     sendMessage(

--- a/lib/src/ssh_client.dart
+++ b/lib/src/ssh_client.dart
@@ -292,7 +292,10 @@ class SSHClient {
 
   final _channelIdAllocator = SSHChannelIdAllocator();
 
-  final _channelOpenReplyWaiters = <int, Completer<SSHMessage>>{};
+  /// Channels for which SSH_MSG_CHANNEL_OPEN has been sent and a matching
+  /// confirmation or failure has not yet been received.
+  final _pendingChannelOpens =
+      <SSHChannelId, Completer<SSHChannelController>>{};
 
   final _channels = <int, SSHChannelController>{};
 
@@ -780,16 +783,17 @@ class SSHClient {
     }
     _keepAlive?.stop();
 
-    // Complete any pending channel-open waiters so callers (e.g.
-    // forwardLocalUnix) don't hang forever when the connection drops.
-    for (final entry in _channelOpenReplyWaiters.entries) {
+    for (final entry in _pendingChannelOpens.entries) {
       if (!entry.value.isCompleted) {
         entry.value.completeError(
-          SSHStateError('Connection closed while waiting for channel open'),
+          SSHStateError(
+            'Connection closed while opening channel ${entry.key}',
+          ),
         );
       }
+      _channelIdAllocator.release(entry.key);
     }
-    _channelOpenReplyWaiters.clear();
+    _pendingChannelOpens.clear();
 
     try {
       _closeChannels();
@@ -1099,14 +1103,14 @@ class SSHClient {
       data: Uint8List(0),
     );
 
-    _sendMessage(confirmation);
-
     final channelController = _acceptChannel(
       localChannelId: localChannelId,
       remoteChannelId: message.senderChannel,
       remoteInitialWindowSize: message.initialWindowSize,
       remoteMaximumPacketSize: message.maximumPacketSize,
     );
+
+    _sendMessage(confirmation);
 
     remoteForward._connections.add(
       SSHForwardChannel(channelController.channel),
@@ -1136,14 +1140,14 @@ class SSHClient {
       data: Uint8List(0),
     );
 
-    _sendMessage(confirmation);
-
     final channelController = _acceptChannel(
       localChannelId: localChannelId,
       remoteChannelId: message.senderChannel,
       remoteInitialWindowSize: message.initialWindowSize,
       remoteMaximumPacketSize: message.maximumPacketSize,
     );
+
+    _sendMessage(confirmation);
 
     onX11Forward!(
       SSHX11Channel(
@@ -1175,14 +1179,14 @@ class SSHClient {
       maximumPacketSize: _maximumPacketSize,
       data: Uint8List(0),
     );
-    _sendMessage(confirmation);
-
     final channelController = _acceptChannel(
       localChannelId: localChannelId,
       remoteChannelId: message.senderChannel,
       remoteInitialWindowSize: message.initialWindowSize,
       remoteMaximumPacketSize: message.maximumPacketSize,
     );
+
+    _sendMessage(confirmation);
 
     SSHAgentChannel(
       channelController.channel,
@@ -1202,24 +1206,39 @@ class SSHClient {
   void _handleChannelConfirmation(Uint8List payload) {
     final message = SSH_Message_Channel_Confirmation.decode(payload);
     printTrace?.call('<- $socket: $message');
-    // Register the channel synchronously BEFORE completing the future.
-    // CHANNEL_DATA for this channel may arrive in the same TCP segment as
-    // the CONFIRMATION. If we defer registration to the async continuation
-    // of _waitChannelOpen, that data hits _handleChannelData while
-    // _channels[id] is still null and is silently dropped.
-    _acceptChannel(
+
+    final pending = _requirePendingChannelOpen(
+      message.recipientChannel,
+      'confirmation',
+    );
+
+    // Register synchronously before completing the future. CHANNEL_DATA may
+    // immediately follow the confirmation in the same transport input.
+    final channelController = _acceptChannel(
       localChannelId: message.recipientChannel,
       remoteChannelId: message.senderChannel,
       remoteInitialWindowSize: message.initialWindowSize,
       remoteMaximumPacketSize: message.maximumPacketSize,
     );
-    _dispatchChannelOpenReply(message.recipientChannel, message);
+
+    _pendingChannelOpens.remove(message.recipientChannel);
+    pending.complete(channelController);
   }
 
   void _handleChannelOpenFailure(Uint8List payload) {
     final message = SSH_Message_Channel_Open_Failure.decode(payload);
     printTrace?.call('<- $socket: $message');
-    _dispatchChannelOpenReply(message.recipientChannel, message);
+
+    final pending = _requirePendingChannelOpen(
+      message.recipientChannel,
+      'failure',
+    );
+
+    _pendingChannelOpens.remove(message.recipientChannel);
+    _channelIdAllocator.release(message.recipientChannel);
+    pending.completeError(
+      SSHChannelOpenError(message.reasonCode, message.description),
+    );
   }
 
   void _handleChannelWindowAdjust(Uint8List payload) {
@@ -1403,7 +1422,7 @@ class SSHClient {
     );
   }
 
-  Future<SSHChannelController> _openSessionChannel() async {
+  Future<SSHChannelController> _openSessionChannel() {
     final localChannelId = _channelIdAllocator.allocate();
 
     final request = SSH_Message_Channel_Open.session(
@@ -1411,9 +1430,7 @@ class SSHClient {
       initialWindowSize: _initialWindowSize,
       maximumPacketSize: _maximumPacketSize,
     );
-    _sendMessage(request);
-
-    return await _waitChannelOpen(localChannelId);
+    return _sendChannelOpen(request);
   }
 
   Future<SSHChannelController> _openForwardLocalChannel(
@@ -1421,7 +1438,7 @@ class SSHClient {
     int bindPort,
     String remoteAddress,
     int remotePort,
-  ) async {
+  ) {
     final localChannelId = _channelIdAllocator.allocate();
 
     final request = SSH_Message_Channel_Open.directTcpip(
@@ -1433,14 +1450,12 @@ class SSHClient {
       originatorIP: bindAddress,
       originatorPort: bindPort,
     );
-    _sendMessage(request);
-
-    return await _waitChannelOpen(localChannelId);
+    return _sendChannelOpen(request);
   }
 
   Future<SSHChannelController> _openForwardLocalUnixChannel(
     String socketPath,
-  ) async {
+  ) {
     final localChannelId = _channelIdAllocator.allocate();
 
     final request = SSH_Message_Channel_Open.directStreamLocal(
@@ -1449,21 +1464,31 @@ class SSHClient {
       maximumPacketSize: _maximumPacketSize,
       socketPath: socketPath,
     );
-    _sendMessage(request);
-
-    return await _waitChannelOpen(localChannelId);
+    return _sendChannelOpen(request);
   }
 
-  Future<SSHChannelController> _waitChannelOpen(
-    SSHChannelId localChannelId,
-  ) async {
-    final message = await _waitChannelOpenReply(localChannelId);
-    if (message is SSH_Message_Channel_Open_Failure) {
-      throw SSHChannelOpenError(message.reasonCode, message.description);
+  Future<SSHChannelController> _sendChannelOpen(
+    SSH_Message_Channel_Open request,
+  ) {
+    final localChannelId = request.senderChannel;
+    if (_pendingChannelOpens.containsKey(localChannelId) ||
+        _channels.containsKey(localChannelId)) {
+      throw SSHStateError('Channel $localChannelId is already in use');
     }
 
-    // Channel was already registered synchronously in _handleChannelConfirmation.
-    return _channels[localChannelId]!;
+    final pending = Completer<SSHChannelController>();
+    _pendingChannelOpens[localChannelId] = pending;
+
+    try {
+      _sendMessage(request);
+    } catch (_) {
+      if (identical(_pendingChannelOpens.remove(localChannelId), pending)) {
+        _channelIdAllocator.release(localChannelId);
+      }
+      rethrow;
+    }
+
+    return pending.future;
   }
 
   SSHChannelController _acceptChannel({
@@ -1472,6 +1497,10 @@ class SSHClient {
     required int remoteInitialWindowSize,
     required int remoteMaximumPacketSize,
   }) {
+    if (_channels.containsKey(localChannelId)) {
+      throw SSHStateError('Channel $localChannelId is already open');
+    }
+
     final channelController = SSHChannelController(
       localId: localChannelId,
       localInitialWindowSize: _initialWindowSize,
@@ -1488,23 +1517,17 @@ class SSHClient {
     return channelController;
   }
 
-  Future<SSHMessage> _waitChannelOpenReply(SSHChannelId id) async {
-    if (_channelOpenReplyWaiters.containsKey(id)) {
-      printDebug?.call('_waitChannelOpenReply: already waiting for $id');
-      return _channelOpenReplyWaiters[id]!.future;
+  Completer<SSHChannelController> _requirePendingChannelOpen(
+    SSHChannelId id,
+    String replyType,
+  ) {
+    final pending = _pendingChannelOpens[id];
+    if (pending == null) {
+      throw SSHStateError(
+        'Received channel open $replyType for non-opening channel $id',
+      );
     }
-    final replyCompleter = Completer<SSHMessage>();
-    _channelOpenReplyWaiters[id] = replyCompleter;
-    return replyCompleter.future;
-  }
-
-  void _dispatchChannelOpenReply(SSHChannelId id, SSHMessage message) {
-    if (!_channelOpenReplyWaiters.containsKey(id)) {
-      printDebug?.call('_dispatchChannelOpenReply: no pending request for $id');
-      return;
-    }
-    final replyCompleter = _channelOpenReplyWaiters.remove(id)!;
-    replyCompleter.complete(message);
+    return pending;
   }
 }
 

--- a/test/src/ssh_channel_test.dart
+++ b/test/src/ssh_channel_test.dart
@@ -1,21 +1,170 @@
+import 'dart:typed_data';
+
+import 'package:dartssh2/src/message/msg_channel.dart';
 import 'package:dartssh2/src/ssh_channel.dart';
+import 'package:dartssh2/src/ssh_errors.dart';
+import 'package:dartssh2/src/ssh_message.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('exposes distinct local and remote channel IDs', () {
-    final controller = SSHChannelController(
-      localId: 1,
-      localMaximumPacketSize: 1024,
-      localInitialWindowSize: 1024,
-      remoteId: 42,
-      remoteMaximumPacketSize: 1024,
-      remoteInitialWindowSize: 0,
-      sendMessage: (_) {},
-    );
+  group('SSHChannelController', () {
+    test('exposes distinct local and remote channel IDs', () {
+      final controller = _createController();
 
-    final channel = controller.channel;
+      final channel = controller.channel;
 
-    expect(channel.channelId, 1);
-    expect(channel.remoteChannelId, 42);
+      expect(channel.channelId, 1);
+      expect(channel.remoteChannelId, 42);
+    });
+
+    test('adjusts the local window when it is exactly exhausted', () async {
+      final sent = <SSHMessage>[];
+      final controller = _createController(
+        localInitialWindowSize: 4,
+        localMaximumPacketSize: 4,
+        sendMessage: sent.add,
+      );
+      final subscription = controller.channel.stream.listen((_) {});
+
+      controller.handleMessage(
+        SSH_Message_Channel_Data(
+          recipientChannel: 1,
+          data: Uint8List(4),
+        ),
+      );
+
+      final adjustment = sent.single as SSH_Message_Channel_Window_Adjust;
+      expect(adjustment.recipientChannel, 42);
+      expect(adjustment.bytesToAdd, 4);
+      await subscription.cancel();
+    });
+
+    test('allows the remote window to reach uint32 max without wrapping', () {
+      final controller = _createController(remoteInitialWindowSize: 0);
+
+      controller.handleMessage(
+        SSH_Message_Channel_Window_Adjust(
+          recipientChannel: 1,
+          bytesToAdd: 0xffffffff,
+        ),
+      );
+
+      expect(
+        () => controller.handleMessage(
+          SSH_Message_Channel_Window_Adjust(
+            recipientChannel: 1,
+            bytesToAdd: 1,
+          ),
+        ),
+        throwsA(isA<SSHStateError>()),
+      );
+    });
+
+    test('rejects data larger than the advertised maximum packet size', () {
+      final sent = <SSHMessage>[];
+      final controller = _createController(
+        localInitialWindowSize: 8,
+        localMaximumPacketSize: 4,
+        sendMessage: sent.add,
+      );
+
+      expect(
+        () => controller.handleMessage(
+          SSH_Message_Channel_Data(
+            recipientChannel: 1,
+            data: Uint8List(5),
+          ),
+        ),
+        throwsA(isA<SSHStateError>()),
+      );
+      expect(sent, isEmpty);
+    });
+
+    test('rejects data larger than the remaining local window', () {
+      final sent = <SSHMessage>[];
+      final controller = _createController(
+        localInitialWindowSize: 4,
+        localMaximumPacketSize: 8,
+        sendMessage: sent.add,
+      );
+
+      expect(
+        () => controller.handleMessage(
+          SSH_Message_Channel_Data(
+            recipientChannel: 1,
+            data: Uint8List(5),
+          ),
+        ),
+        throwsA(isA<SSHStateError>()),
+      );
+      expect(sent, isEmpty);
+    });
+
+    test('applies packet and window limits to extended data', () async {
+      final sent = <SSHMessage>[];
+      final controller = _createController(
+        localInitialWindowSize: 4,
+        localMaximumPacketSize: 4,
+        sendMessage: sent.add,
+      );
+      final subscription = controller.channel.stream.listen((_) {});
+
+      controller.handleMessage(
+        SSH_Message_Channel_Extended_Data(
+          recipientChannel: 1,
+          dataTypeCode: SSH_Message_Channel_Extended_Data.dataTypeStderr,
+          data: Uint8List(4),
+        ),
+      );
+
+      final adjustment = sent.single as SSH_Message_Channel_Window_Adjust;
+      expect(adjustment.bytesToAdd, 4);
+
+      expect(
+        () => controller.handleMessage(
+          SSH_Message_Channel_Extended_Data(
+            recipientChannel: 1,
+            dataTypeCode: SSH_Message_Channel_Extended_Data.dataTypeStderr,
+            data: Uint8List(5),
+          ),
+        ),
+        throwsA(isA<SSHStateError>()),
+      );
+      expect(sent, hasLength(1));
+
+      final windowController = _createController(
+        localInitialWindowSize: 4,
+        localMaximumPacketSize: 8,
+      );
+      expect(
+        () => windowController.handleMessage(
+          SSH_Message_Channel_Extended_Data(
+            recipientChannel: 1,
+            dataTypeCode: SSH_Message_Channel_Extended_Data.dataTypeStderr,
+            data: Uint8List(5),
+          ),
+        ),
+        throwsA(isA<SSHStateError>()),
+      );
+
+      await subscription.cancel();
+    });
   });
+}
+
+SSHChannelController _createController({
+  int localInitialWindowSize = 1024,
+  int localMaximumPacketSize = 1024,
+  int remoteInitialWindowSize = 0,
+  void Function(SSHMessage)? sendMessage,
+}) {
+  return SSHChannelController(
+    localId: 1,
+    localMaximumPacketSize: localMaximumPacketSize,
+    localInitialWindowSize: localInitialWindowSize,
+    remoteId: 42,
+    remoteMaximumPacketSize: 1024,
+    remoteInitialWindowSize: remoteInitialWindowSize,
+    sendMessage: sendMessage ?? (_) {},
+  );
 }

--- a/test/src/ssh_client_channel_open_test.dart
+++ b/test/src/ssh_client_channel_open_test.dart
@@ -1,0 +1,255 @@
+import 'dart:async';
+import 'dart:mirrors';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:dartssh2/src/message/msg_channel.dart';
+import 'package:dartssh2/src/ssh_channel.dart';
+import 'package:dartssh2/src/ssh_channel_id.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SSHClient channel open state', () {
+    late _FakeSSHSocket socket;
+    late SSHClient client;
+
+    setUp(() {
+      socket = _FakeSSHSocket();
+      client = SSHClient(
+        socket,
+        username: 'test',
+        onX11Forward: (_) {},
+      );
+    });
+
+    tearDown(() async {
+      await client.close();
+    });
+
+    test('records the opening state before sending SSH_MSG_CHANNEL_OPEN',
+        () async {
+      _disableRekeyBuffer(client);
+      var pendingAtSend = false;
+      socket.onWrite = (_) {
+        pendingAtSend = _pendingChannelOpens(client).containsKey(0);
+      };
+
+      final openFuture = _openSessionChannel(client);
+      final expectation = expectLater(
+        openFuture,
+        throwsA(isA<SSHStateError>()),
+      );
+      socket.onWrite = null;
+
+      expect(pendingAtSend, isTrue);
+      expect(_pendingChannelOpens(client), contains(0));
+
+      await client.close();
+      await expectation;
+    });
+
+    test('registers a confirmed channel before dispatching following data',
+        () async {
+      final openFuture = _openSessionChannel(client);
+
+      client.handlePacket(_confirmation(0).encode());
+      expect(_openChannels(client), contains(0));
+      expect(_pendingChannelOpens(client), isEmpty);
+
+      client.handlePacket(
+        SSH_Message_Channel_Data(
+          recipientChannel: 0,
+          data: Uint8List.fromList([1, 2, 3]),
+        ).encode(),
+      );
+
+      final controller = await openFuture;
+      expect(controller.remoteId, 42);
+      expect(
+        await controller.channel.stream.first,
+        isA<SSHChannelData>().having(
+          (data) => data.bytes,
+          'bytes',
+          orderedEquals([1, 2, 3]),
+        ),
+      );
+    });
+
+    test('registers an accepted inbound channel before sending confirmation',
+        () {
+      _disableRekeyBuffer(client);
+      var openAtSend = false;
+      socket.onWrite = (_) {
+        openAtSend = _openChannels(client).containsKey(0);
+      };
+
+      client.handlePacket(
+        SSH_Message_Channel_Open.x11(
+          senderChannel: 42,
+          initialWindowSize: 1024,
+          maximumPacketSize: 1024,
+          originatorIP: '127.0.0.1',
+          originatorPort: 1234,
+        ).encode(),
+      );
+      socket.onWrite = null;
+
+      expect(openAtSend, isTrue);
+      expect(_openChannels(client), contains(0));
+    });
+
+    test('completes a matching failure and releases its channel ID', () async {
+      final openFuture = _openSessionChannel(client);
+      final expectation = expectLater(
+        openFuture,
+        throwsA(
+          isA<SSHChannelOpenError>()
+              .having((error) => error.code, 'code', 2)
+              .having((error) => error.description, 'description', 'denied'),
+        ),
+      );
+
+      client.handlePacket(
+        SSH_Message_Channel_Open_Failure(
+          recipientChannel: 0,
+          reasonCode: 2,
+          description: 'denied',
+        ).encode(),
+      );
+
+      await expectation;
+      expect(_pendingChannelOpens(client), isEmpty);
+      expect(_allocatedChannelIds(client), isEmpty);
+    });
+
+    test('rejects unsolicited channel open confirmations', () {
+      expect(
+        () => client.handlePacket(_confirmation(7).encode()),
+        throwsA(isA<SSHStateError>()),
+      );
+      expect(_openChannels(client), isEmpty);
+    });
+
+    test('rejects unsolicited channel open failures', () {
+      final failure = SSH_Message_Channel_Open_Failure(
+        recipientChannel: 7,
+        reasonCode: 2,
+        description: 'denied',
+      );
+
+      expect(
+        () => client.handlePacket(failure.encode()),
+        throwsA(isA<SSHStateError>()),
+      );
+    });
+
+    test('rejects duplicate channel open confirmations', () async {
+      final openFuture = _openSessionChannel(client);
+      final confirmation = _confirmation(0);
+
+      client.handlePacket(confirmation.encode());
+      await openFuture;
+
+      expect(
+        () => client.handlePacket(confirmation.encode()),
+        throwsA(isA<SSHStateError>()),
+      );
+    });
+
+    test('fails pending opens and releases their IDs when transport closes',
+        () async {
+      final openFuture = _openSessionChannel(client);
+      final expectation = expectLater(
+        openFuture,
+        throwsA(isA<SSHStateError>()),
+      );
+
+      await client.close();
+      await expectation;
+
+      expect(_pendingChannelOpens(client), isEmpty);
+      expect(_allocatedChannelIds(client), isEmpty);
+    });
+  });
+}
+
+SSH_Message_Channel_Confirmation _confirmation(int recipientChannel) {
+  return SSH_Message_Channel_Confirmation(
+    recipientChannel: recipientChannel,
+    senderChannel: 42,
+    initialWindowSize: 1024,
+    maximumPacketSize: 1024,
+    data: Uint8List(0),
+  );
+}
+
+Future<SSHChannelController> _openSessionChannel(SSHClient client) {
+  return reflect(client)
+          .invoke(_clientSymbol('_openSessionChannel'), const []).reflectee
+      as Future<SSHChannelController>;
+}
+
+Map _pendingChannelOpens(SSHClient client) {
+  return reflect(client)
+      .getField(_clientSymbol('_pendingChannelOpens'))
+      .reflectee as Map;
+}
+
+Map _openChannels(SSHClient client) {
+  return reflect(client).getField(_clientSymbol('_channels')).reflectee as Map;
+}
+
+Set _allocatedChannelIds(SSHClient client) {
+  final allocator =
+      reflect(client).getField(_clientSymbol('_channelIdAllocator')).reflectee;
+  final library = reflectClass(SSHChannelIdAllocator).owner as LibraryMirror;
+  final symbol = MirrorSystem.getSymbol('_allocated', library);
+  return reflect(allocator).getField(symbol).reflectee as Set;
+}
+
+Symbol _clientSymbol(String name) {
+  final library = reflectClass(SSHClient).owner as LibraryMirror;
+  return MirrorSystem.getSymbol(name, library);
+}
+
+void _disableRekeyBuffer(SSHClient client) {
+  final transport = reflect(client).getField(_clientSymbol('_transport'));
+  final library = transport.type.owner as LibraryMirror;
+  final symbol = MirrorSystem.getSymbol('_kexInProgress', library);
+  transport.setField(symbol, false);
+}
+
+class _FakeSSHSocket implements SSHSocket {
+  final _input = StreamController<Uint8List>();
+  final _output = StreamController<List<int>>.broadcast(sync: true);
+
+  void Function(List<int>)? onWrite;
+
+  _FakeSSHSocket() {
+    _output.stream.listen((data) => onWrite?.call(data));
+  }
+
+  @override
+  Stream<Uint8List> get stream => _input.stream;
+
+  @override
+  StreamSink<List<int>> get sink => _output.sink;
+
+  @override
+  Future<void> get done => _input.done;
+
+  @override
+  Future<void> close() async {
+    if (!_input.isClosed) await _input.close();
+    if (!_output.isClosed) await _output.close();
+  }
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  void destroy() {
+    _input.close();
+    _output.close();
+  }
+}


### PR DESCRIPTION
RFC 4254 limits channel windows to an unsigned 32-bit value and requires data packets to stay within both the current window and the advertised maximum packet size. OpenSSH also treats window overflow and open replies for channels that are not in the opening state as protocol errors.

The previous implementation could leave a channel stuck when its local window reached zero, let receive windows become negative, and accept unsolicited channel-open confirmations. It also registered outbound open waiters only after sending the request, leaving the state transition ordered incorrectly.