### PR TITLE
ci: skip the coverage upload on Dependabot pull requests

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -57,6 +57,14 @@ jobs:
         run: dart test --tags=integration
 
       - name: Upload coverage
+        # Dependabot pull requests run without access to repository secrets, so
+        # CODECOV_TOKEN arrives empty and Codecov rejects the upload with
+        # "Token required because branch is protected". Combined with
+        # fail_ci_if_error that turns every dependency bump red for a reason
+        # that has nothing to do with the change. Pull requests from forks are
+        # not affected: they upload without a token because the head branch
+        # does not belong to this repository.
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v7
         with:
           # Fail loudly. With this off, the upload 404'd for every run after


### PR DESCRIPTION
Fixes the failing check on #209.

## What happens

Dependabot pull requests run without access to repository secrets, so `secrets.CODECOV_TOKEN` expands to an empty string. Codecov then rejects the upload:

```
Upload queued for processing failed: {"message":"Token required because branch is protected"}
==> Failed to run upload-coverage
Error: Process completed with exit code 1.
```

Because `fail_ci_if_error: true` is set, the whole job goes red. Every dependency bump would fail for a reason that has nothing to do with the bump.