### PR TITLE
Fix pending futures when SSH components terminate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [3.1.0] - 2026-08-17
+- Fixed operations hanging forever when the component they were waiting on terminated. A channel request, a global request or a channel open whose reply could no longer arrive now fails with the error that ended the connection or the channel, instead of leaving the caller awaiting a reply that will never come [#212]. Thanks [@GT-610].
+- Changed `SSH_MSG_CHANNEL_CLOSE`, channel destruction and transport termination to be terminal for pending replies, while `SSH_MSG_CHANNEL_EOF` remains non-terminal, since RFC 4254 allows request replies to arrive after EOF [#212]. Thanks [@GT-610].
 - Fixed a channel stalling forever once a slow reader paused the stream: the receive window was never replenished after it reached zero, so the channel could not accept another byte for the rest of its life. This affected any slow consumer, such as an SFTP download or shell output [#210]. Thanks [@GT-610].
 - Added the channel limits required by RFC 4254 §5.2: data beyond the advertised maximum packet size or beyond the remaining receive window is rejected, and a window adjustment that would overflow the 32-bit window is refused [#210]. Thanks [@GT-610].
 - Changed a peer that breaks those limits to fail only the affected channel, raising the error on its stream so the caller finds out, while the connection and its other channels stay alive.

--- a/lib/src/sftp/sftp_client.dart
+++ b/lib/src/sftp/sftp_client.dart
@@ -17,6 +17,8 @@ import 'package:dartssh2/src/ssh_channel.dart';
 import 'package:dartssh2/src/ssh_transport.dart';
 import 'package:dartssh2/src/utils/chunk_buffer.dart';
 import 'package:dartssh2/src/ssh_message.dart';
+import 'package:dartssh2/src/utils/pending_requests.dart';
+import 'package:dartssh2/src/utils/terminal_state.dart';
 
 part 'sftp_file.dart';
 
@@ -38,19 +40,32 @@ class SftpClient {
   final SSHPrintHandler? printTrace;
 
   SftpClient(this._channel, {this.printDebug, this.printTrace}) {
+    _handshake.future.ignore();
+    _channel.stream.listen(
+      _handleData,
+      onError: (Object error, StackTrace stackTrace) {
+        _closeError(error, stackTrace);
+      },
+      onDone: () {
+        _closeError(SftpAbortError('SFTP channel closed'));
+      },
+    );
     _startHandshake();
-    _channel.stream.listen(_handleData);
   }
 
   final _buffer = ChunkBuffer();
 
   final _handshake = Completer<SftpHandsake>();
 
-  final _done = Completer<void>();
+  final _terminalState = TerminalState();
 
   final _requestId = SftpRequestId();
 
-  final _replyWaiters = <int, Completer<SftpResponsePacket>>{};
+  late final _replyWaiters = PendingRequests<int, SftpResponsePacket>(
+    terminalState: _terminalState,
+  );
+
+  Future<void>? _closeFuture;
 
   /// The handshake information received from the server.
   Future<SftpHandsake> get handshake => _handshake.future;
@@ -240,23 +255,22 @@ class SftpClient {
   /// a fresh session channel, so an application that opens an sftp session per
   /// operation would accumulate open channels on the connection until the
   /// server refuses further `CHANNEL_OPEN`s.
-  Future<void> close() async {
-    if (_done.isCompleted) return;
-    for (var waiter in _replyWaiters.values) {
-      waiter.completeError(SftpAbortError("Connection closed"));
-    }
-    _replyWaiters.clear();
-    _done.complete();
+  Future<void> close() => _closeFuture ??= _closeClient();
+
+  Future<void> _closeClient() async {
+    _closeError(SftpAbortError('SFTP client closed'));
     await _channel.close();
   }
 
   void _closeError(Object error, [StackTrace? stackTrace]) {
     stackTrace ??= StackTrace.current;
-    for (var waiter in _replyWaiters.values) {
-      waiter.completeError(error, stackTrace);
+    final didTerminate = _replyWaiters.closeWithError(error, stackTrace);
+    if (!didTerminate) return;
+
+    _buffer.clear();
+    if (!_handshake.isCompleted) {
+      _handshake.completeError(_terminalState.error, _terminalState.stackTrace);
     }
-    _replyWaiters.clear();
-    _done.completeError(error, stackTrace);
   }
 
   void _startHandshake() {
@@ -288,6 +302,7 @@ class SftpClient {
   }
 
   void _sendPacket(SftpPacket packet) {
+    _terminalState.throwIfTerminated();
     printTrace?.call('-> $_channel: $packet');
     final data = packet.encode();
     final writer = SSHMessageWriter();
@@ -299,7 +314,12 @@ class SftpClient {
   Future<SftpResponsePacket> _sendRequest(SftpRequestPacket request) async {
     await handshake;
     final reply = _waitReply(request.requestId);
-    _sendPacket(request);
+    try {
+      _sendPacket(request);
+    } catch (error, stackTrace) {
+      _replyWaiters.fail(request.requestId, error, stackTrace);
+      _closeError(error, stackTrace);
+    }
     return await reply;
   }
 
@@ -436,14 +456,11 @@ class SftpClient {
   }
 
   void _dispatchReply(SftpResponsePacket packet) {
-    final completer = _replyWaiters.remove(packet.requestId);
-    completer?.complete(packet);
+    _replyWaiters.complete(packet.requestId, packet);
   }
 
   Future<SftpResponsePacket> _waitReply(int requestId) {
-    final completer = Completer<SftpResponsePacket>();
-    _replyWaiters[requestId] = completer;
-    return completer.future;
+    return _replyWaiters.wait(requestId);
   }
 
   Future<void> _checkExtension(String name, String version) async {
@@ -458,8 +475,13 @@ class SftpClient {
   }
 
   void _handleData(SSHChannelData data) {
-    _buffer.add(data.bytes);
-    _handlePackets();
+    if (_terminalState.isTerminated) return;
+    try {
+      _buffer.add(data.bytes);
+      _handlePackets();
+    } catch (error, stackTrace) {
+      _closeError(error, stackTrace);
+    }
   }
 
   void _handlePackets() {
@@ -496,6 +518,11 @@ class SftpClient {
   }
 
   void _handleVersionPacket(Uint8List payload) {
+    if (_handshake.isCompleted) {
+      _closeError(SftpError('Unexpected version packet'));
+      return;
+    }
+
     final packet = SftpVersionPacket.decode(payload);
     printTrace?.call('<- $_channel: $packet');
 
@@ -504,9 +531,7 @@ class SftpClient {
       return _handshake.complete(handshake);
     }
 
-    final error = SftpError('Version mismatch: ${packet.version}');
-    _handshake.completeError(error, StackTrace.current);
-    _closeError(error);
+    _closeError(SftpError('Version mismatch: ${packet.version}'));
   }
 
   void _handleStatusPacket(Uint8List payload) {

--- a/lib/src/ssh_channel.dart
+++ b/lib/src/ssh_channel.dart
@@ -4,12 +4,13 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:dartssh2/src/ssh_channel_id.dart';
+import 'package:dartssh2/src/ssh_errors.dart';
 import 'package:dartssh2/src/ssh_transport.dart';
 import 'package:dartssh2/src/utils/async_queue.dart';
 import 'package:dartssh2/src/message/msg_channel.dart';
-import 'package:dartssh2/src/ssh_errors.dart';
 import 'package:dartssh2/src/ssh_message.dart';
 import 'package:dartssh2/src/utils/stream.dart';
+import 'package:dartssh2/src/utils/terminal_state.dart';
 
 const _maxChannelWindow = 0xffffffff;
 
@@ -71,8 +72,12 @@ class SSHChannelController {
   /// Handler of channel requests from the remote side.
   late var _requestHandler = _defaultRequestHandler;
 
+  final _terminalState = TerminalState();
+
   /// An [AsyncQueue] of pending request replies from the remote side.
-  final _requestReplyQueue = AsyncQueue<bool>();
+  late final _requestReplyQueue = AsyncQueue<bool>(
+    terminalState: _terminalState,
+  );
 
   /// true if we have sent an EOF message to the remote side.
   var _hasSentEOF = false;
@@ -82,15 +87,14 @@ class SSHChannelController {
 
   final _done = Completer<void>();
 
-  Future<bool> sendExec(String command) async {
-    sendMessage(
+  Future<bool> sendExec(String command) {
+    return _sendRequest(
       SSH_Message_Channel_Request.exec(
         recipientChannel: remoteId,
         wantReply: true,
         command: command,
       ),
     );
-    return await _requestReplyQueue.next;
   }
 
   Future<bool> sendPtyReq({
@@ -100,8 +104,8 @@ class SSHChannelController {
     int terminalPixelWidth = 0,
     int terminalPixelHeight = 0,
     Uint8List? terminalModes,
-  }) async {
-    sendMessage(
+  }) {
+    return _sendRequest(
       SSH_Message_Channel_Request.pty(
         recipientChannel: remoteId,
         termType: terminalType,
@@ -113,17 +117,15 @@ class SSHChannelController {
         wantReply: true,
       ),
     );
-    return await _requestReplyQueue.next;
   }
 
-  Future<bool> sendShell() async {
-    sendMessage(
+  Future<bool> sendShell() {
+    return _sendRequest(
       SSH_Message_Channel_Request.shell(
         recipientChannel: remoteId,
         wantReply: true,
       ),
     );
-    return await _requestReplyQueue.next;
   }
 
   Future<bool> sendX11Req({
@@ -131,8 +133,8 @@ class SSHChannelController {
     String authenticationProtocol = 'MIT-MAGIC-COOKIE-1',
     required String authenticationCookie,
     int screenNumber = 0,
-  }) async {
-    sendMessage(
+  }) {
+    return _sendRequest(
       SSH_Message_Channel_Request.x11(
         recipientChannel: remoteId,
         wantReply: true,
@@ -142,33 +144,30 @@ class SSHChannelController {
         x11ScreenNumber: screenNumber,
       ),
     );
-    return await _requestReplyQueue.next;
   }
 
-  Future<bool> sendAgentForwardingRequest() async {
-    sendMessage(
+  Future<bool> sendAgentForwardingRequest() {
+    return _sendRequest(
       SSH_Message_Channel_Request(
         recipientChannel: remoteId,
         requestType: SSHChannelRequestType.authAgent,
         wantReply: true,
       ),
     );
-    return await _requestReplyQueue.next;
   }
 
-  Future<bool> sendSubsystem(String subsystem) async {
-    sendMessage(
+  Future<bool> sendSubsystem(String subsystem) {
+    return _sendRequest(
       SSH_Message_Channel_Request.subsystem(
         recipientChannel: remoteId,
         subsystemName: subsystem,
         wantReply: true,
       ),
     );
-    return await _requestReplyQueue.next;
   }
 
-  Future<bool> sendEnv(String name, String value) async {
-    sendMessage(
+  Future<bool> sendEnv(String name, String value) {
+    return _sendRequest(
       SSH_Message_Channel_Request.env(
         recipientChannel: remoteId,
         variableName: name,
@@ -176,10 +175,10 @@ class SSHChannelController {
         wantReply: true,
       ),
     );
-    return await _requestReplyQueue.next;
   }
 
   void sendSignal(String signal) {
+    _terminalState.throwIfTerminated();
     sendMessage(
       SSH_Message_Channel_Request.signal(
         recipientChannel: remoteId,
@@ -194,6 +193,7 @@ class SSHChannelController {
     required int pixelWidth,
     required int pixelHeight,
   }) {
+    _terminalState.throwIfTerminated();
     sendMessage(
       SSH_Message_Channel_Request.windowChange(
         recipientChannel: remoteId,
@@ -237,7 +237,7 @@ class SSHChannelController {
 
     if (_remoteStream.isClosed) {
       _sendCloseIfNeeded();
-      _done.complete();
+      _finish(SSHStateError('Channel closed before receiving request reply'));
       return;
     }
 
@@ -247,13 +247,34 @@ class SSHChannelController {
   /// Closes the channel immediately in both directions. This may send a close
   /// message to the remote side. After this no more data can be sent or
   /// received.
-  void destroy() {
+  void destroy([Object? error, StackTrace? stackTrace]) {
     if (_done.isCompleted) return;
     _remoteStream.close();
     _locaStreamConsumer.cancel();
     _sendEOFIfNeeded();
     _sendCloseIfNeeded();
-    _done.complete();
+    _finish(
+      error ?? SSHStateError('Channel destroyed before receiving reply'),
+      stackTrace,
+    );
+  }
+
+  Future<bool> _sendRequest(SSHMessage request) async {
+    final reply = _requestReplyQueue.next;
+    try {
+      sendMessage(request);
+    } catch (error, stackTrace) {
+      _requestReplyQueue.closeWithError(error, stackTrace);
+      rethrow;
+    }
+    return await reply;
+  }
+
+  void _finish(Object error, [StackTrace? stackTrace]) {
+    _requestReplyQueue.closeWithError(error, stackTrace);
+    if (!_done.isCompleted) {
+      _done.complete();
+    }
   }
 
   void _handleWindowAdjustMessage(int bytesToAdd) {
@@ -361,7 +382,7 @@ class SSHChannelController {
   void _handleCloseMessage() {
     printDebug?.call('SSHChannel._handleCLoseMessage');
     _remoteStream.close();
-    close();
+    unawaited(close());
   }
 
   bool _defaultRequestHandler(SSH_Message_Channel_Request request) {
@@ -373,7 +394,12 @@ class SSHChannelController {
     if (_done.isCompleted) return;
     if (_hasSentEOF) return;
     _hasSentEOF = true;
-    sendMessage(SSH_Message_Channel_EOF(recipientChannel: remoteId));
+
+    try {
+      sendMessage(SSH_Message_Channel_EOF(recipientChannel: remoteId));
+    } catch (e) {
+      printDebug?.call('SSHChannelController._sendEOFIfNeeded - error: $e');
+    }
   }
 
   void _sendCloseIfNeeded() {
@@ -459,8 +485,10 @@ class SSHChannelController {
     }
   });
 
-  Future<void> flush() async {
-    await onFlush?.call();
+  Future<void> flush() {
+    return _terminalState.bind(() async {
+      await onFlush?.call();
+    });
   }
 }
 

--- a/lib/src/ssh_client.dart
+++ b/lib/src/ssh_client.dart
@@ -16,6 +16,8 @@ import 'package:dartssh2/src/ssh_identity.dart';
 import 'package:dartssh2/src/ssh_session.dart';
 import 'package:dartssh2/src/ssh_transport.dart';
 import 'package:dartssh2/src/utils/async_queue.dart';
+import 'package:dartssh2/src/utils/pending_requests.dart';
+import 'package:dartssh2/src/utils/terminal_state.dart';
 import 'package:dartssh2/src/message/msg_channel.dart';
 import 'package:dartssh2/src/message/msg_request.dart';
 import 'package:dartssh2/src/message/msg_service.dart';
@@ -243,8 +245,9 @@ class SSHClient {
 
     _transport.done.then(
       (_) => _handleTransportClosed(null),
-      onError: (e) => _handleTransportClosed(
-        e is SSHError ? e : SSHSocketError(e),
+      onError: (Object error, StackTrace stackTrace) => _handleTransportClosed(
+        error is SSHError ? error : SSHSocketError(error),
+        stackTrace,
       ),
     );
 
@@ -288,14 +291,20 @@ class SSHClient {
   /// completes with an error if the client could not authenticate.
   final _authenticated = Completer<void>();
 
-  final _globalRequestReplyQueue = AsyncQueue<SSHMessage>();
+  final _terminalState = TerminalState();
+
+  late final _globalRequestReplyQueue = AsyncQueue<SSHMessage>(
+    terminalState: _terminalState,
+  );
 
   final _channelIdAllocator = SSHChannelIdAllocator();
 
   /// Channels for which SSH_MSG_CHANNEL_OPEN has been sent and a matching
   /// confirmation or failure has not yet been received.
-  final _pendingChannelOpens =
-      <SSHChannelId, Completer<SSHChannelController>>{};
+  late final _pendingChannelOpens =
+      PendingRequests<SSHChannelId, SSHChannelController>(
+    terminalState: _terminalState,
+  );
 
   final _channels = <int, SSHChannelController>{};
 
@@ -364,8 +373,9 @@ class SSHClient {
     // Lisning on a random port if not specified.
     port ??= 0;
 
-    _sendMessage(SSH_Message_Global_Request.tcpipForward(host, port));
-    final reply = await _globalRequestReplyQueue.next;
+    final reply = await _sendGlobalRequest(
+      SSH_Message_Global_Request.tcpipForward(host, port),
+    );
 
     if (reply is SSH_Message_Request_Failure) return null;
 
@@ -390,14 +400,13 @@ class SSHClient {
 
     if (!_remoteForwards.remove(forward)) return false;
 
-    _sendMessage(
+    final reply = await _sendGlobalRequest(
       SSH_Message_Global_Request.cancelTcpipForward(
         bindAddress: forward.host,
         bindPort: forward.port,
       ),
     );
 
-    final reply = await _globalRequestReplyQueue.next;
     if (reply is SSH_Message_Request_Failure) {
       return false;
     }
@@ -727,8 +736,7 @@ class SSHClient {
   /// Send a empty message to the server to keep the connection alive.
   Future<void> ping() async {
     await _authenticated.future;
-    _sendMessage(SSH_Message_Global_Request.keepAlive());
-    await _globalRequestReplyQueue.next;
+    await _sendGlobalRequest(SSH_Message_Global_Request.keepAlive());
   }
 
   /// Shutdown the entire SSH connection. Sessions and channels will also be
@@ -736,7 +744,9 @@ class SSHClient {
   Future<void> close() async {
     _handshakeTimeoutTimer?.cancel();
     _authTimeoutTimer?.cancel();
-    _closeChannels();
+    final error = SSHStateError('SSH client closed');
+    _terminatePendingOperations(error);
+    _closeChannels(error);
     await _transport.close();
   }
 
@@ -746,9 +756,9 @@ class SSHClient {
   }
 
   /// Close all channels that are currently open.
-  void _closeChannels() {
+  void _closeChannels([Object? error, StackTrace? stackTrace]) {
     for (final channel in _channels.values) {
-      channel.destroy();
+      channel.destroy(error, stackTrace);
       _channelIdAllocator.release(channel.localId);
     }
 
@@ -769,7 +779,7 @@ class SSHClient {
     _requestAuthentication();
   }
 
-  void _handleTransportClosed(SSHError? error) {
+  void _handleTransportClosed(SSHError? error, [StackTrace? stackTrace]) {
     printDebug?.call('SSHClient._onTransportClosed');
     _handshakeTimeoutTimer?.cancel();
     _handshakeTimeoutTimer = null;
@@ -783,23 +793,33 @@ class SSHClient {
     }
     _keepAlive?.stop();
 
-    for (final entry in _pendingChannelOpens.entries) {
-      if (!entry.value.isCompleted) {
-        entry.value.completeError(
-          SSHStateError(
-            'Connection closed while opening channel ${entry.key}',
-          ),
-        );
-      }
-      _channelIdAllocator.release(entry.key);
-    }
-    _pendingChannelOpens.clear();
+    final terminalError = error ?? SSHStateError('SSH connection closed');
+    _terminatePendingOperations(terminalError, stackTrace);
 
     try {
-      _closeChannels();
+      _closeChannels(terminalError, stackTrace);
     } catch (e) {
       printDebug?.call("SSHClient::_handleTransportClosed - error: $e");
     }
+  }
+
+  void _terminatePendingOperations(Object error, [StackTrace? stackTrace]) {
+    _globalRequestReplyQueue.closeWithError(error, stackTrace);
+
+    for (final id in _pendingChannelOpens.keys) {
+      _channelIdAllocator.release(id);
+    }
+    _pendingChannelOpens.closeWithError(error, stackTrace);
+  }
+
+  Future<SSHMessage> _sendGlobalRequest(SSHMessage request) async {
+    final reply = _globalRequestReplyQueue.next;
+    try {
+      _sendMessage(request);
+    } catch (error, stackTrace) {
+      _terminatePendingOperations(error, stackTrace);
+    }
+    return await reply;
   }
 
   void _handlePacket(Uint8List payload) {
@@ -1207,10 +1227,7 @@ class SSHClient {
     final message = SSH_Message_Channel_Confirmation.decode(payload);
     printTrace?.call('<- $socket: $message');
 
-    final pending = _requirePendingChannelOpen(
-      message.recipientChannel,
-      'confirmation',
-    );
+    _requirePendingChannelOpen(message.recipientChannel, 'confirmation');
 
     // Register synchronously before completing the future. CHANNEL_DATA may
     // immediately follow the confirmation in the same transport input.
@@ -1221,22 +1238,18 @@ class SSHClient {
       remoteMaximumPacketSize: message.maximumPacketSize,
     );
 
-    _pendingChannelOpens.remove(message.recipientChannel);
-    pending.complete(channelController);
+    _pendingChannelOpens.complete(message.recipientChannel, channelController);
   }
 
   void _handleChannelOpenFailure(Uint8List payload) {
     final message = SSH_Message_Channel_Open_Failure.decode(payload);
     printTrace?.call('<- $socket: $message');
 
-    final pending = _requirePendingChannelOpen(
-      message.recipientChannel,
-      'failure',
-    );
+    _requirePendingChannelOpen(message.recipientChannel, 'failure');
 
-    _pendingChannelOpens.remove(message.recipientChannel);
     _channelIdAllocator.release(message.recipientChannel);
-    pending.completeError(
+    _pendingChannelOpens.fail(
+      message.recipientChannel,
       SSHChannelOpenError(message.reasonCode, message.description),
     );
   }
@@ -1430,7 +1443,7 @@ class SSHClient {
       initialWindowSize: _initialWindowSize,
       maximumPacketSize: _maximumPacketSize,
     );
-    return _sendChannelOpen(request);
+    return _openChannel(localChannelId, request);
   }
 
   Future<SSHChannelController> _openForwardLocalChannel(
@@ -1450,7 +1463,7 @@ class SSHClient {
       originatorIP: bindAddress,
       originatorPort: bindPort,
     );
-    return _sendChannelOpen(request);
+    return _openChannel(localChannelId, request);
   }
 
   Future<SSHChannelController> _openForwardLocalUnixChannel(
@@ -1464,31 +1477,32 @@ class SSHClient {
       maximumPacketSize: _maximumPacketSize,
       socketPath: socketPath,
     );
-    return _sendChannelOpen(request);
+    return _openChannel(localChannelId, request);
   }
 
-  Future<SSHChannelController> _sendChannelOpen(
+  Future<SSHChannelController> _openChannel(
+    SSHChannelId localChannelId,
     SSH_Message_Channel_Open request,
   ) {
-    final localChannelId = request.senderChannel;
-    if (_pendingChannelOpens.containsKey(localChannelId) ||
+    if (_pendingChannelOpens.isWaiting(localChannelId) ||
         _channels.containsKey(localChannelId)) {
       throw SSHStateError('Channel $localChannelId is already in use');
     }
 
-    final pending = Completer<SSHChannelController>();
-    _pendingChannelOpens[localChannelId] = pending;
+    // Registered before sending so a reply delivered synchronously by the
+    // transport still finds its waiter.
+    final reply = _pendingChannelOpens.wait(localChannelId);
 
     try {
       _sendMessage(request);
-    } catch (_) {
-      if (identical(_pendingChannelOpens.remove(localChannelId), pending)) {
+    } catch (error, stackTrace) {
+      if (_pendingChannelOpens.fail(localChannelId, error, stackTrace)) {
         _channelIdAllocator.release(localChannelId);
       }
       rethrow;
     }
 
-    return pending.future;
+    return reply;
   }
 
   SSHChannelController _acceptChannel({
@@ -1517,17 +1531,11 @@ class SSHClient {
     return channelController;
   }
 
-  Completer<SSHChannelController> _requirePendingChannelOpen(
-    SSHChannelId id,
-    String replyType,
-  ) {
-    final pending = _pendingChannelOpens[id];
-    if (pending == null) {
-      throw SSHStateError(
-        'Received channel open $replyType for non-opening channel $id',
-      );
-    }
-    return pending;
+  void _requirePendingChannelOpen(SSHChannelId id, String replyType) {
+    if (_pendingChannelOpens.isWaiting(id)) return;
+    throw SSHStateError(
+      'Received channel open $replyType for non-opening channel $id',
+    );
   }
 }
 

--- a/lib/src/utils/async_queue.dart
+++ b/lib/src/utils/async_queue.dart
@@ -2,8 +2,15 @@ import 'dart:async';
 
 import 'dart:collection';
 
+import 'package:dartssh2/src/utils/terminal_state.dart';
+
 /// A queue that consumers can wait asynchronously for items to be added.
 class AsyncQueue<T> {
+  AsyncQueue({TerminalState? terminalState})
+    : terminalState = terminalState ?? TerminalState();
+
+  final TerminalState terminalState;
+
   final _data = Queue<T>();
 
   final _completers = Queue<Completer<T>>();
@@ -16,6 +23,7 @@ class AsyncQueue<T> {
 
   /// Returns a [Future] that completes when an item is added to the queue.
   FutureOr<T> get next {
+    terminalState.throwIfTerminated();
     if (_data.isNotEmpty) {
       return _data.removeFirst();
     } else {
@@ -27,10 +35,25 @@ class AsyncQueue<T> {
 
   /// Adds an item to the queue.
   void add(T value) {
+    if (terminalState.isTerminated) return;
     if (_completers.isNotEmpty) {
       _completers.removeFirst().complete(value);
     } else {
       _data.add(value);
     }
+  }
+
+  /// Terminates this queue and fails all current and future waiters.
+  bool closeWithError(Object error, [StackTrace? stackTrace]) {
+    final didTerminate = terminalState.terminate(error, stackTrace);
+    final terminalError = terminalState.error;
+    final terminalStackTrace = terminalState.stackTrace;
+
+    for (final completer in _completers) {
+      completer.completeError(terminalError, terminalStackTrace);
+    }
+    _completers.clear();
+    _data.clear();
+    return didTerminate;
   }
 }

--- a/lib/src/utils/async_queue.dart
+++ b/lib/src/utils/async_queue.dart
@@ -7,7 +7,7 @@ import 'package:dartssh2/src/utils/terminal_state.dart';
 /// A queue that consumers can wait asynchronously for items to be added.
 class AsyncQueue<T> {
   AsyncQueue({TerminalState? terminalState})
-    : terminalState = terminalState ?? TerminalState();
+      : terminalState = terminalState ?? TerminalState();
 
   final TerminalState terminalState;
 

--- a/lib/src/utils/pending_requests.dart
+++ b/lib/src/utils/pending_requests.dart
@@ -5,7 +5,7 @@ import 'package:dartssh2/src/utils/terminal_state.dart';
 /// Futures waiting for replies identified by a request key.
 class PendingRequests<K, V> {
   PendingRequests({TerminalState? terminalState})
-    : terminalState = terminalState ?? TerminalState();
+      : terminalState = terminalState ?? TerminalState();
 
   final TerminalState terminalState;
 

--- a/lib/src/utils/pending_requests.dart
+++ b/lib/src/utils/pending_requests.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:dartssh2/src/utils/terminal_state.dart';
+
+/// Futures waiting for replies identified by a request key.
+class PendingRequests<K, V> {
+  PendingRequests({TerminalState? terminalState})
+    : terminalState = terminalState ?? TerminalState();
+
+  final TerminalState terminalState;
+
+  final _completers = <K, Completer<V>>{};
+
+  /// The keys that currently have a waiter.
+  Iterable<K> get keys => _completers.keys.toList(growable: false);
+
+  /// Whether [key] currently has a waiter.
+  bool isWaiting(K key) => _completers.containsKey(key);
+
+  /// Returns the existing waiter for [key], or registers a new one.
+  Future<V> wait(K key) {
+    terminalState.throwIfTerminated();
+    return _completers.putIfAbsent(key, Completer<V>.new).future;
+  }
+
+  /// Completes the waiter for [key]. Returns false if there is no waiter.
+  bool complete(K key, V value) {
+    final completer = _completers.remove(key);
+    if (completer == null) return false;
+    completer.complete(value);
+    return true;
+  }
+
+  /// Fails the waiter for [key]. Returns false if there is no waiter.
+  bool fail(K key, Object error, [StackTrace? stackTrace]) {
+    final completer = _completers.remove(key);
+    if (completer == null) return false;
+    completer.completeError(error, stackTrace ?? StackTrace.current);
+    return true;
+  }
+
+  /// Terminates this collection and fails all current and future waiters.
+  bool closeWithError(Object error, [StackTrace? stackTrace]) {
+    final didTerminate = terminalState.terminate(error, stackTrace);
+    final terminalError = terminalState.error;
+    final terminalStackTrace = terminalState.stackTrace;
+
+    for (final completer in _completers.values) {
+      completer.completeError(terminalError, terminalStackTrace);
+    }
+    _completers.clear();
+    return didTerminate;
+  }
+}

--- a/lib/src/utils/terminal_state.dart
+++ b/lib/src/utils/terminal_state.dart
@@ -1,0 +1,53 @@
+import 'dart:async';
+
+/// Stores the first error that makes an asynchronous component unusable.
+class TerminalState {
+  bool get isTerminated => _error != null;
+
+  Object get error {
+    final error = _error;
+    if (error == null) {
+      throw StateError('The component has not terminated');
+    }
+    return error;
+  }
+
+  StackTrace get stackTrace {
+    if (_error == null) {
+      throw StateError('The component has not terminated');
+    }
+    return _stackTrace!;
+  }
+
+  Object? _error;
+  StackTrace? _stackTrace;
+  final _terminated = Completer<void>();
+
+  /// Records [error] if this is the first terminal event.
+  bool terminate(Object error, [StackTrace? stackTrace]) {
+    if (isTerminated) return false;
+    _error = error;
+    _stackTrace = stackTrace ?? StackTrace.current;
+    _terminated.complete();
+    return true;
+  }
+
+  /// Throws the recorded terminal error, if any.
+  void throwIfTerminated() {
+    if (!isTerminated) return;
+    Error.throwWithStackTrace(error, stackTrace);
+  }
+
+  /// Runs [operation] and fails it if this state terminates first.
+  Future<T> bind<T>(FutureOr<T> Function() operation) {
+    if (isTerminated) {
+      return Future<T>.error(error, stackTrace);
+    }
+
+    final operationFuture = Future<T>.sync(operation);
+    final terminationFuture = _terminated.future.then<T>((_) {
+      Error.throwWithStackTrace(error, stackTrace);
+    });
+    return Future.any([operationFuture, terminationFuture]);
+  }
+}

--- a/test/src/sftp/sftp_client_protocol_test.dart
+++ b/test/src/sftp/sftp_client_protocol_test.dart
@@ -99,6 +99,75 @@ void main() {
       harness.dispose();
     });
 
+    test('remote channel close aborts the handshake', () async {
+      final harness = _SftpHarness();
+      await harness.nextOutgoingPacket();
+      final handshakeExpectation = expectLater(
+        harness.client.handshake,
+        throwsA(isA<SftpAbortError>()),
+      );
+
+      harness.closeRemote();
+
+      await handshakeExpectation;
+      harness.dispose();
+    });
+
+    test('remote channel close aborts pending requests', () async {
+      final harness = _SftpHarness();
+      await harness.nextOutgoingPacket();
+      harness.sendResponsePacket(SftpVersionPacket(3));
+      await harness.client.handshake;
+
+      final openFuture = harness.client.open('/tmp/f');
+      await harness.nextOutgoingPacket();
+      final openExpectation = expectLater(
+        openFuture,
+        throwsA(isA<SftpAbortError>()),
+      );
+
+      harness.closeRemote();
+
+      await openExpectation;
+      harness.dispose();
+    });
+
+    test('stream error and done terminate the client only once', () async {
+      final channel = _SynchronousResponseChannel();
+      final client = SftpClient(channel);
+      final error = StateError('stream failed');
+      final handshakeExpectation = expectLater(
+        client.handshake,
+        throwsA(same(error)),
+      );
+
+      channel.fail(error);
+      await channel.finish();
+
+      await handshakeExpectation;
+      await expectLater(client.close(), completes);
+      await expectLater(client.close(), completes);
+    });
+
+    test('requests after stream termination fail before sending a packet',
+        () async {
+      final channel = _SynchronousResponseChannel();
+      final client = SftpClient(channel);
+      channel.sendResponsePacket(SftpVersionPacket(3));
+      await client.handshake;
+
+      await channel.finish();
+      await Future<void>.delayed(Duration.zero);
+      final packetsBeforeRequest = channel.outboundPacketCount;
+
+      await expectLater(
+        client.stat('/tmp/f'),
+        throwsA(isA<SftpAbortError>()),
+      );
+      expect(channel.outboundPacketCount, packetsBeforeRequest);
+      await client.close();
+    });
+
     test('close closes the underlying channel', () async {
       final harness = _SftpHarness();
       await harness.nextOutgoingPacket();
@@ -813,12 +882,14 @@ class _SynchronousResponseChannel extends SSHChannel {
 
   final _incoming = StreamController<SSHChannelData>(sync: true);
   SftpPacket Function(Uint8List payload)? _outboundResponder;
+  var outboundPacketCount = 0;
 
   @override
   Stream<SSHChannelData> get stream => _incoming.stream;
 
   @override
   void addData(Uint8List data, {int? type}) {
+    outboundPacketCount++;
     final reader = SSHMessageReader(data);
     final length = reader.readUint32();
     final payload = reader.readBytes(length);
@@ -841,6 +912,12 @@ class _SynchronousResponseChannel extends SSHChannel {
     writer.writeBytes(payload);
     _incoming.add(SSHChannelData(writer.takeBytes()));
   }
+
+  void fail(Object error, [StackTrace? stackTrace]) {
+    _incoming.addError(error, stackTrace ?? StackTrace.current);
+  }
+
+  Future<void> finish() => _incoming.close();
 
   @override
   Future<void> close() => _incoming.close();

--- a/test/src/ssh_channel_terminal_test.dart
+++ b/test/src/ssh_channel_terminal_test.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+
+import 'package:dartssh2/src/message/msg_channel.dart';
+import 'package:dartssh2/src/ssh_channel.dart';
+import 'package:dartssh2/src/ssh_errors.dart';
+import 'package:dartssh2/src/ssh_message.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SSHChannel terminal state', () {
+    test(
+      'remote close fails a pending request and rejects later requests',
+      () async {
+        final sent = <SSHMessage>[];
+        final controller = _controller(sendMessage: sent.add);
+        final pending = controller.channel.sendShell();
+        final pendingExpectation = expectLater(
+          pending,
+          throwsA(isA<SSHStateError>()),
+        );
+
+        controller.handleMessage(
+          SSH_Message_Channel_Close(recipientChannel: controller.localId),
+        );
+
+        await pendingExpectation;
+        await expectLater(controller.channel.done, completes);
+
+        final sentBeforeRetry = sent.length;
+        await expectLater(
+          controller.channel.sendShell(),
+          throwsA(isA<SSHStateError>()),
+        );
+        expect(sent, hasLength(sentBeforeRetry));
+
+        expect(() => controller.destroy(), returnsNormally);
+      },
+    );
+
+    test('destroy fails pending requests and flushes idempotently', () async {
+      final flushCompleter = Completer<void>();
+      final controller = _controller(
+        sendMessage: (_) {},
+        onFlush: () => flushCompleter.future,
+      );
+      final request = controller.channel.sendExec('true');
+      final flush = controller.channel.flush();
+      final expectations = [
+        expectLater(request, throwsA(isA<SSHStateError>())),
+        expectLater(flush, throwsA(isA<SSHStateError>())),
+      ];
+
+      controller.destroy();
+      controller.destroy();
+
+      await Future.wait(expectations);
+    });
+
+    test('EOF alone does not terminate pending channel requests', () async {
+      final controller = _controller(sendMessage: (_) {});
+      final pending = controller.channel.sendShell();
+
+      controller.handleMessage(
+        SSH_Message_Channel_EOF(recipientChannel: controller.localId),
+      );
+      controller.handleMessage(
+        SSH_Message_Channel_Success(recipientChannel: controller.localId),
+      );
+
+      await expectLater(pending, completion(isTrue));
+      controller.destroy();
+    });
+
+    test('a completed request is unaffected by later destruction', () async {
+      final controller = _controller(sendMessage: (_) {});
+      final pending = controller.channel.sendShell();
+
+      controller.handleMessage(
+        SSH_Message_Channel_Success(recipientChannel: controller.localId),
+      );
+      controller.destroy();
+
+      await expectLater(pending, completion(isTrue));
+    });
+  });
+}
+
+SSHChannelController _controller({
+  required void Function(SSHMessage) sendMessage,
+  Future<void> Function()? onFlush,
+}) {
+  return SSHChannelController(
+    localId: 1,
+    localMaximumPacketSize: 1024,
+    localInitialWindowSize: 1024,
+    remoteId: 2,
+    remoteMaximumPacketSize: 1024,
+    remoteInitialWindowSize: 0,
+    sendMessage: sendMessage,
+    onFlush: onFlush,
+  );
+}

--- a/test/src/ssh_client_channel_open_test.dart
+++ b/test/src/ssh_client_channel_open_test.dart
@@ -31,7 +31,7 @@ void main() {
       _disableRekeyBuffer(client);
       var pendingAtSend = false;
       socket.onWrite = (_) {
-        pendingAtSend = _pendingChannelOpens(client).containsKey(0);
+        pendingAtSend = _pendingChannelOpens(client).contains(0);
       };
 
       final openFuture = _openSessionChannel(client);
@@ -237,10 +237,11 @@ Future<SSHChannelController> _openSessionChannel(SSHClient client) {
       as Future<SSHChannelController>;
 }
 
-Map _pendingChannelOpens(SSHClient client) {
-  return reflect(client)
-      .getField(_clientSymbol('_pendingChannelOpens'))
-      .reflectee as Map;
+/// The channel IDs with an open still awaiting a confirmation or failure.
+Iterable _pendingChannelOpens(SSHClient client) {
+  final pending =
+      reflect(client).getField(_clientSymbol('_pendingChannelOpens')).reflectee;
+  return reflect(pending).getField(#keys).reflectee as Iterable;
 }
 
 Map _openChannels(SSHClient client) {

--- a/test/src/ssh_client_terminal_test.dart
+++ b/test/src/ssh_client_terminal_test.dart
@@ -18,19 +18,18 @@ void main() {
     final socket = _FakeSSHSocket();
     final client = SSHClient(socket, username: 'demo', keepAliveInterval: null);
     final clientMirror = reflect(client);
-    final authenticated =
-        clientMirror.getField(privateSymbol('_authenticated')).reflectee
-            as Completer<void>;
+    final authenticated = clientMirror
+        .getField(privateSymbol('_authenticated'))
+        .reflectee as Completer<void>;
     authenticated.complete();
 
     final channelController =
         clientMirror.invoke(privateSymbol('_acceptChannel'), const [], {
-              #localChannelId: 99,
-              #remoteChannelId: 100,
-              #remoteInitialWindowSize: 0,
-              #remoteMaximumPacketSize: 1024,
-            }).reflectee
-            as SSHChannelController;
+      #localChannelId: 99,
+      #remoteChannelId: 100,
+      #remoteInitialWindowSize: 0,
+      #remoteMaximumPacketSize: 1024,
+    }).reflectee as SSHChannelController;
 
     final ping = client.ping();
     final open = client.forwardLocal('example.com', 22);

--- a/test/src/ssh_client_terminal_test.dart
+++ b/test/src/ssh_client_terminal_test.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+import 'dart:mirrors';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:dartssh2/src/ssh_channel.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final clientLibrary = reflectClass(SSHClient).owner as LibraryMirror;
+  Symbol privateSymbol(String name) =>
+      MirrorSystem.getSymbol(name, clientLibrary);
+  final transportLibrary = reflectClass(SSHTransport).owner as LibraryMirror;
+  Symbol transportPrivateSymbol(String name) =>
+      MirrorSystem.getSymbol(name, transportLibrary);
+
+  test('transport termination fails every pending SSH reply waiter', () async {
+    final socket = _FakeSSHSocket();
+    final client = SSHClient(socket, username: 'demo', keepAliveInterval: null);
+    final clientMirror = reflect(client);
+    final authenticated =
+        clientMirror.getField(privateSymbol('_authenticated')).reflectee
+            as Completer<void>;
+    authenticated.complete();
+
+    final channelController =
+        clientMirror.invoke(privateSymbol('_acceptChannel'), const [], {
+              #localChannelId: 99,
+              #remoteChannelId: 100,
+              #remoteInitialWindowSize: 0,
+              #remoteMaximumPacketSize: 1024,
+            }).reflectee
+            as SSHChannelController;
+
+    final ping = client.ping();
+    final open = client.forwardLocal('example.com', 22);
+    final request = channelController.channel.sendShell();
+    await Future<void>.delayed(Duration.zero);
+
+    final expectations = [
+      expectLater(ping, throwsA(isA<SSHStateError>())),
+      expectLater(open, throwsA(isA<SSHStateError>())),
+      expectLater(request, throwsA(isA<SSHStateError>())),
+    ];
+
+    await socket.closeRemote();
+
+    await Future.wait(expectations);
+    expect(
+      () => clientMirror.invoke(privateSymbol('_handleTransportClosed'), [
+        SSHStateError('later'),
+      ]),
+      returnsNormally,
+    );
+
+    final writesBeforeRetry = socket.writeCount;
+    await expectLater(client.ping(), throwsA(isA<SSHStateError>()));
+    await expectLater(
+      client.forwardLocal('example.com', 22),
+      throwsA(isA<SSHStateError>()),
+    );
+    await expectLater(
+      channelController.channel.sendShell(),
+      throwsA(isA<SSHStateError>()),
+    );
+    expect(socket.writeCount, writesBeforeRetry);
+
+    await client.close();
+  });
+
+  test('send failure terminates reply waiters without leaving a gap', () async {
+    final socket = _FakeSSHSocket();
+    final client = SSHClient(
+      socket,
+      username: 'demo',
+      keepAliveInterval: null,
+    );
+    final authenticated = reflect(client)
+        .getField(privateSymbol('_authenticated'))
+        .reflectee as Completer<void>;
+    authenticated.complete();
+    final transport = reflect(client)
+        .getField(privateSymbol('_transport'))
+        .reflectee as SSHTransport;
+    reflect(transport).setField(
+      transportPrivateSymbol('_kexInProgress'),
+      false,
+    );
+
+    final error = StateError('write failed');
+    socket.writeError = error;
+
+    await expectLater(client.ping(), throwsA(same(error)));
+    final writesBeforeRetry = socket.writeCount;
+    await expectLater(
+      client.forwardLocal('example.com', 22),
+      throwsA(same(error)),
+    );
+    expect(socket.writeCount, writesBeforeRetry);
+
+    socket.writeError = null;
+    await client.close();
+  });
+}
+
+class _FakeSSHSocket implements SSHSocket {
+  final _inputController = StreamController<Uint8List>();
+  final _doneCompleter = Completer<void>();
+  late final _sink = _RecordingSink(_recordWrite);
+
+  var writeCount = 0;
+  Object? writeError;
+
+  void _recordWrite() {
+    writeCount++;
+    final error = writeError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Stream<Uint8List> get stream => _inputController.stream;
+
+  @override
+  StreamSink<List<int>> get sink => _sink;
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  @override
+  Future<void> close() async {
+    if (!_doneCompleter.isCompleted) {
+      _doneCompleter.complete();
+    }
+    await _inputController.close();
+  }
+
+  Future<void> closeRemote() => _inputController.close();
+
+  @override
+  void destroy() {
+    if (!_doneCompleter.isCompleted) {
+      _doneCompleter.complete();
+    }
+    unawaited(_inputController.close());
+  }
+
+  @override
+  Future<void> flush() async {}
+}
+
+class _RecordingSink implements StreamSink<List<int>> {
+  _RecordingSink(this._onAdd);
+
+  final void Function() _onAdd;
+
+  @override
+  void add(List<int> data) => _onAdd();
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) async {
+    await for (final data in stream) {
+      add(data);
+    }
+  }
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> get done async {}
+}

--- a/test/src/utils/terminal_state_test.dart
+++ b/test/src/utils/terminal_state_test.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:dartssh2/src/utils/async_queue.dart';
+import 'package:dartssh2/src/utils/pending_requests.dart';
+import 'package:dartssh2/src/utils/terminal_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AsyncQueue terminal state', () {
+    test(
+      'fails current and future waiters with the first terminal error',
+      () async {
+        final queue = AsyncQueue<int>();
+        final error = StateError('closed');
+        final pending = queue.next as Future<int>;
+        final pendingExpectation = expectLater(pending, throwsA(same(error)));
+
+        expect(queue.closeWithError(error), isTrue);
+        expect(queue.closeWithError(StateError('later')), isFalse);
+
+        await pendingExpectation;
+        expect(() => queue.next, throwsA(same(error)));
+      },
+    );
+
+    test('does not change a waiter that already received its value', () async {
+      final queue = AsyncQueue<int>();
+      final pending = queue.next as Future<int>;
+
+      queue.add(7);
+      queue.closeWithError(StateError('closed'));
+
+      await expectLater(pending, completion(7));
+    });
+  });
+
+  group('PendingRequests terminal state', () {
+    test(
+      'fails keyed waiters and rejects new keys after termination',
+      () async {
+        final requests = PendingRequests<int, String>();
+        final error = StateError('closed');
+        final first = requests.wait(1);
+        final second = requests.wait(2);
+        final expectations = [
+          expectLater(first, throwsA(same(error))),
+          expectLater(second, throwsA(same(error))),
+        ];
+
+        requests.closeWithError(error);
+
+        await Future.wait(expectations);
+        expect(() => requests.wait(3), throwsA(same(error)));
+      },
+    );
+
+    test('does not change a request that already completed', () async {
+      final requests = PendingRequests<int, String>();
+      final pending = requests.wait(1);
+
+      expect(requests.complete(1, 'ok'), isTrue);
+      requests.closeWithError(StateError('closed'));
+
+      await expectLater(pending, completion('ok'));
+    });
+  });
+
+  group('TerminalState.bind', () {
+    test('fails an operation when termination wins the race', () async {
+      final state = TerminalState();
+      final operation = Completer<void>();
+      final error = StateError('closed');
+      final bound = state.bind(() => operation.future);
+      final expectation = expectLater(bound, throwsA(same(error)));
+
+      state.terminate(error);
+
+      await expectation;
+    });
+
+    test('preserves an operation that completed before termination', () async {
+      final state = TerminalState();
+      final bound = state.bind(() async => 7);
+
+      await expectLater(bound, completion(7));
+      state.terminate(StateError('closed'));
+    });
+  });
+}


### PR DESCRIPTION
`SSH_MSG_CHANNEL_EOF` remains non-terminal, so request replies may still arrive after EOF. `SSH_MSG_CHANNEL_CLOSE`, local destruction, and transport termination enter the terminal state and fail operations that can no longer receive a reply, consistent with RFC 4254 and OpenSSH behavior.

The first terminal error and stack trace are retained and propagated to both current and future waiters.