### PR TITLE
fix: limit SFTP packet sizes

### DIFF
--- a/lib/src/sftp/sftp_client.dart
+++ b/lib/src/sftp/sftp_client.dart
@@ -31,6 +31,9 @@ const _kReadMaxPendingRequests = 64;
 const _kMinReadSize = 512;
 const _kDownloadChunkSize = 64 * 1024;
 const _kDownloadMaxPendingRequests = 128;
+// Matches SFTP_MAX_MSG_LENGTH in OpenSSH. The four-byte length prefix is not
+// included in this limit.
+const _kMaxPacketLength = 256 * 1024;
 
 class SftpClient {
   final SSHChannel _channel;
@@ -303,8 +306,17 @@ class SftpClient {
 
   void _sendPacket(SftpPacket packet) {
     _terminalState.throwIfTerminated();
-    printTrace?.call('-> $_channel: $packet');
     final data = packet.encode();
+    if (data.length > _kMaxPacketLength) {
+      final error = SftpError(
+        'Outgoing SFTP packet is too large: ${data.length} bytes '
+        '(maximum $_kMaxPacketLength bytes)',
+      );
+      _closeError(error);
+      _channel.destroy();
+      throw error;
+    }
+    printTrace?.call('-> $_channel: $packet');
     final writer = SSHMessageWriter();
     writer.writeUint32(data.length);
     writer.writeBytes(data);
@@ -488,6 +500,16 @@ class SftpClient {
     const lengthHeader = 4; // 4 bytes packet length header
     while (_buffer.length >= lengthHeader) {
       final length = _buffer.byteData.getUint32(0);
+      if (length > _kMaxPacketLength) {
+        _closeError(
+          SftpError(
+            'Incoming SFTP packet is too large: $length bytes '
+            '(maximum $_kMaxPacketLength bytes)',
+          ),
+        );
+        _channel.destroy();
+        return;
+      }
       if (_buffer.length < lengthHeader + length) break;
       final packet = _buffer.consume(lengthHeader + length);
       final payload = Uint8List.sublistView(packet, lengthHeader);

--- a/test/src/sftp/sftp_client_protocol_test.dart
+++ b/test/src/sftp/sftp_client_protocol_test.dart
@@ -12,6 +12,8 @@ import 'package:dartssh2/src/ssh_channel.dart';
 import 'package:dartssh2/src/ssh_message.dart';
 import 'package:test/test.dart';
 
+const _openSshMaxSftpPacketLength = 256 * 1024;
+
 void main() {
   group('SftpClient protocol', () {
     test('handshake completes with version packet', () async {
@@ -29,6 +31,70 @@ void main() {
       expect(handshake.extensions['fstatvfs@openssh.com'], '2');
 
       harness.dispose();
+    });
+
+    test('accepts an incoming packet at the OpenSSH size limit', () async {
+      final harness = _SftpHarness();
+      await harness.nextOutgoingPacket();
+
+      final payload = Uint8List(_openSshMaxSftpPacketLength);
+      payload[0] = 0xff; // Unknown packets are ignored by the client.
+      harness.sendResponsePayload(payload);
+      harness.sendResponsePacket(SftpVersionPacket(3));
+
+      await expectLater(harness.client.handshake, completes);
+      harness.dispose();
+    });
+
+    test('rejects an oversized incoming packet from its length header',
+        () async {
+      final harness = _SftpHarness();
+      await harness.nextOutgoingPacket();
+      harness.sendResponsePacket(SftpVersionPacket(3));
+      await harness.client.handshake;
+
+      final openFuture = harness.client.open('/tmp/file');
+      await harness.nextOutgoingPacket();
+      final openExpectation = expectLater(
+        openFuture,
+        throwsA(
+          isA<SftpError>().having(
+            (error) => error.message,
+            'message',
+            contains('${_openSshMaxSftpPacketLength + 1} bytes'),
+          ),
+        ),
+      );
+
+      harness.sendResponseLength(_openSshMaxSftpPacketLength + 1);
+
+      await openExpectation;
+      await expectLater(harness.channelDone, completes);
+      harness.dispose();
+    });
+
+    test('rejects an outgoing packet over the OpenSSH size limit', () async {
+      final channel = _SynchronousResponseChannel();
+      final client = SftpClient(channel);
+      channel.sendResponsePacket(SftpVersionPacket(3));
+      await client.handshake;
+      final packetsBeforeRequest = channel.outboundPacketCount;
+      final oversizedPathBytes = Uint8List(_openSshMaxSftpPacketLength)
+        ..fillRange(0, _openSshMaxSftpPacketLength, 0x78);
+      final oversizedPath = String.fromCharCodes(oversizedPathBytes);
+
+      await expectLater(
+        client.stat(oversizedPath),
+        throwsA(
+          isA<SftpError>().having(
+            (error) => error.message,
+            'message',
+            contains('Outgoing SFTP packet is too large'),
+          ),
+        ),
+      );
+      expect(channel.outboundPacketCount, packetsBeforeRequest);
+      await client.close();
     });
 
     test('stat uses lstat when followLink is false', () async {
@@ -843,15 +909,28 @@ class _SftpHarness {
   }
 
   void sendResponsePacket(SftpPacket packet) {
-    final payload = packet.encode();
+    sendResponsePayload(packet.encode());
+  }
+
+  void sendResponsePayload(Uint8List payload) {
     final writer = SSHMessageWriter();
     writer.writeUint32(payload.length);
     writer.writeBytes(payload);
 
+    _sendResponseData(writer.takeBytes());
+  }
+
+  void sendResponseLength(int length) {
+    final writer = SSHMessageWriter();
+    writer.writeUint32(length);
+    _sendResponseData(writer.takeBytes());
+  }
+
+  void _sendResponseData(Uint8List data) {
     _controller.handleMessage(
       SSH_Message_Channel_Data(
         recipientChannel: _controller.localId,
-        data: writer.takeBytes(),
+        data: data,
       ),
     );
   }


### PR DESCRIPTION
The SFTP protocol does not define a fixed maximum packet size, so clients need an implementation safety limit. Without one, a peer can advertise an arbitrarily large packet and make the client keep buffering data while waiting for the declared payload. OpenSSH 10.5 caps both sent and received SFTP messages at 256 KiB; this change follows the same limit and length semantics (the four-byte prefix is excluded).