### PR TITLE
Implement RFC-compliant SSH_MSG_UNIMPLEMENTED handling

### DIFF
--- a/lib/src/message/msg_unimplemented.dart
+++ b/lib/src/message/msg_unimplemented.dart
@@ -1,0 +1,34 @@
+// ignore_for_file: camel_case_types
+
+import 'dart:typed_data';
+
+import 'package:dartssh2/src/ssh_message.dart';
+
+/// SSH_MSG_UNIMPLEMENTED as defined by RFC 4253 section 11.4.
+class SSH_Message_Unimplemented implements SSHMessage {
+  static const messageId = 3;
+
+  /// Sequence number of the rejected packet.
+  final int sequenceNumber;
+
+  SSH_Message_Unimplemented(this.sequenceNumber);
+
+  factory SSH_Message_Unimplemented.decode(Uint8List bytes) {
+    final reader = SSHMessageReader(bytes);
+    reader.skip(1);
+    return SSH_Message_Unimplemented(reader.readUint32());
+  }
+
+  @override
+  Uint8List encode() {
+    final writer = SSHMessageWriter();
+    writer.writeUint8(messageId);
+    writer.writeUint32(sequenceNumber);
+    return writer.takeBytes();
+  }
+
+  @override
+  String toString() {
+    return 'SSH_Message_Unimplemented(sequenceNumber: $sequenceNumber)';
+  }
+}

--- a/lib/src/ssh_client.dart
+++ b/lib/src/ssh_client.dart
@@ -238,7 +238,7 @@ class SSHClient {
       algorithms: algorithms,
       onVerifyHostKey: onVerifyHostKey,
       onReady: _handleTransportReady,
-      onPacket: _handlePacket,
+      onMessage: _handlePacket,
       disableHostkeyVerification: disableHostkeyVerification,
       version: ident,
     );
@@ -822,9 +822,9 @@ class SSHClient {
     return await reply;
   }
 
-  void _handlePacket(Uint8List payload) {
+  bool _handlePacket(Uint8List payload) {
     try {
-      _dispatchMessage(payload);
+      return _dispatchMessage(payload);
     } catch (e) {
       rethrow;
     }
@@ -849,49 +849,69 @@ class SSHClient {
     });
   }
 
-  void _dispatchMessage(Uint8List message) {
+  bool _dispatchMessage(Uint8List message) {
     final messageId = SSHMessage.readMessageId(message);
     switch (messageId) {
       case SSH_Message_Service_Accept.messageId:
-        return _handleServiceAccept(message);
+        _handleServiceAccept(message);
+        return true;
       case SSH_Message_Userauth_Success.messageId:
-        return _handleUserauthSuccess();
+        _handleUserauthSuccess();
+        return true;
       case SSH_Message_Userauth_Failure.messageId:
-        return _handleUserauthFailure(message);
+        _handleUserauthFailure(message);
+        return true;
       case SSH_Message_Userauth_Passwd_ChangeReq.messageId:
-        return _handleUserauthIntermidiate(message);
+        _handleUserauthIntermidiate(message);
+        return true;
       case SSH_Message_Userauth_Banner.messageId:
-        return _handleUserauthBanner(message);
+        _handleUserauthBanner(message);
+        return true;
       case SSH_Message_Global_Request.messageId:
-        return _handleGlobalRequest(message);
+        _handleGlobalRequest(message);
+        return true;
       case SSH_Message_Request_Success.messageId:
-        return _handleGlobalRequestSuccess(message);
+        _handleGlobalRequestSuccess(message);
+        return true;
       case SSH_Message_Request_Failure.messageId:
-        return _handleGlobalRequestFailure(message);
+        _handleGlobalRequestFailure(message);
+        return true;
       case SSH_Message_Channel_Open.messageId:
-        return _handleChannelOpen(message);
+        _handleChannelOpen(message);
+        return true;
       case SSH_Message_Channel_Confirmation.messageId:
-        return _handleChannelConfirmation(message);
+        _handleChannelConfirmation(message);
+        return true;
       case SSH_Message_Channel_Open_Failure.messageId:
-        return _handleChannelOpenFailure(message);
+        _handleChannelOpenFailure(message);
+        return true;
       case SSH_Message_Channel_Window_Adjust.messageId:
-        return _handleChannelWindowAdjust(message);
+        _handleChannelWindowAdjust(message);
+        return true;
       case SSH_Message_Channel_Success.messageId:
-        return _handleChannelSuccess(message);
+        _handleChannelSuccess(message);
+        return true;
       case SSH_Message_Channel_Failure.messageId:
-        return _handleChannelFailure(message);
+        _handleChannelFailure(message);
+        return true;
       case SSH_Message_Channel_Data.messageId:
-        return _handleChannelData(message);
+        _handleChannelData(message);
+        return true;
       case SSH_Message_Channel_Extended_Data.messageId:
-        return _handleChannelExtendedData(message);
+        _handleChannelExtendedData(message);
+        return true;
       case SSH_Message_Channel_EOF.messageId:
-        return _handleChannelEOF(message);
+        _handleChannelEOF(message);
+        return true;
       case SSH_Message_Channel_Close.messageId:
-        return _handleChannelClose(message);
+        _handleChannelClose(message);
+        return true;
       case SSH_Message_Channel_Request.messageId:
-        return _handleChannelRequest(message);
+        _handleChannelRequest(message);
+        return true;
       default:
         printDebug?.call('unknown messageId: $messageId');
+        return false;
     }
   }
 

--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -8,7 +8,11 @@ import 'package:dartssh2/src/hostkey/hostkey_rsa.dart';
 import 'package:dartssh2/src/kex/kex_dh.dart';
 import 'package:dartssh2/src/kex/kex_nist.dart';
 import 'package:dartssh2/src/kex/kex_x25519.dart';
+import 'package:dartssh2/src/message/msg_debug.dart';
+import 'package:dartssh2/src/message/msg_disconnect.dart';
 import 'package:dartssh2/src/message/msg_userauth.dart';
+import 'package:dartssh2/src/message/msg_ignore.dart';
+import 'package:dartssh2/src/message/msg_unimplemented.dart';
 import 'package:dartssh2/src/ssh_algorithm.dart';
 import 'package:dartssh2/src/ssh_kex.dart';
 import 'package:dartssh2/src/utils/bigint.dart';
@@ -48,6 +52,9 @@ Uint8List _hostkeyFingerprint(Uint8List hostkey) {
 typedef SSHTransportReadyHandler = void Function();
 
 typedef SSHPacketHandler = void Function(Uint8List payload);
+
+/// Handles a packet and returns whether its message type is recognized.
+typedef SSHMessageHandler = bool Function(Uint8List payload);
 
 /// Pseudo algorithm names that are advertised inside the key exchange
 /// name-list without being key exchange algorithms themselves.
@@ -97,6 +104,13 @@ class SSHTransport {
   /// Function called when a packet is received.
   final SSHPacketHandler? onPacket;
 
+  /// Function called for messages not handled by the transport layer.
+  ///
+  /// Returning `false` causes the transport to reply with
+  /// SSH_MSG_UNIMPLEMENTED for the current packet. [onPacket] is retained for
+  /// backwards compatibility and assumes every packet it receives is handled.
+  final SSHMessageHandler? onMessage;
+
   /// Whether to bypass server host key verification.
   ///
   /// If set to `true`, the connection will proceed without checking the server's
@@ -125,8 +139,9 @@ class SSHTransport {
     this.onVerifyHostKey,
     this.onReady,
     this.onPacket,
+    this.onMessage,
     this.disableHostkeyVerification = false,
-  }) {
+  }) : assert(onPacket == null || onMessage == null) {
     _initSocket();
     _startHandshake();
   }
@@ -1195,6 +1210,7 @@ class SSHTransport {
     // allowed to appear between KEXINIT and NEWKEYS. Receiving one there means
     // someone is padding the transcript, so the connection is torn down.
     if (_strictKex &&
+        _isFirstKex &&
         _kexInProgress &&
         _isForbiddenDuringStrictKex(messageId)) {
       throw SSHHandshakeError(
@@ -1204,6 +1220,29 @@ class SSHTransport {
     }
 
     switch (messageId) {
+      case SSH_Message_Disconnect.messageId:
+        final disconnect = SSH_Message_Disconnect.decode(message);
+        printTrace?.call('<- $socket: $disconnect');
+        return close();
+      case SSH_Message_Ignore.messageId:
+        final ignore = SSH_Message_Ignore.decode(message);
+        printTrace?.call('<- $socket: $ignore');
+        return;
+      case SSH_Message_Unimplemented.messageId:
+        final unimplemented = SSH_Message_Unimplemented.decode(message);
+        printTrace?.call('<- $socket: $unimplemented');
+        printDebug?.call(
+          'Received SSH_MSG_UNIMPLEMENTED for packet '
+          '${unimplemented.sequenceNumber}',
+        );
+        return;
+      case SSH_Message_Debug.messageId:
+        final debug = SSH_Message_Debug.decode(message);
+        printTrace?.call('<- $socket: $debug');
+        printDebug?.call(
+          'Remote: ${utf8.decode(debug.message, allowMalformed: true)}',
+        );
+        return;
       case SSH_Message_KexInit.messageId:
         return _handleMessageKexInit(message);
       case SSH_Message_KexDH_Reply.messageId:
@@ -1212,10 +1251,55 @@ class SSHTransport {
       case SSH_Message_NewKeys.messageId:
         return _handleMessageNewKeys(message);
       case SSH_Message_ExtInfo.messageId:
+        if (_kexInProgress) {
+          return _handleUnexpectedKexMessage(messageId);
+        }
         return _handleMessageExtInfo(message);
       default:
-        onPacket?.call(message);
+        if (_kexInProgress) {
+          return _handleUnexpectedKexMessage(messageId);
+        }
+
+        final messageHandler = onMessage;
+        if (messageHandler != null) {
+          if (messageHandler(message)) return;
+        } else {
+          final packetHandler = onPacket;
+          if (packetHandler != null) {
+            packetHandler(message);
+            return;
+          }
+        }
+
+        _sendUnimplemented(messageId);
     }
+  }
+
+  /// Handles a message that is not valid during the current key exchange.
+  ///
+  /// OpenSSH disconnects for unexpected messages during the initial strict
+  /// key exchange. For non-strict exchanges and rekeys, it reports the
+  /// message as unimplemented.
+  void _handleUnexpectedKexMessage(int messageId) {
+    if (_strictKex && _isFirstKex) {
+      throw SSHHandshakeError(
+        'Strict key exchange violation: unexpected message $messageId '
+        'received during key exchange',
+      );
+    }
+    _sendUnimplemented(messageId);
+  }
+
+  /// Reports an unrecognized message using the rejected packet's sequence
+  /// number, before [_processPackets] advances it.
+  void _sendUnimplemented(int messageId) {
+    final message = SSH_Message_Unimplemented(_remotePacketSN.value);
+    printDebug?.call(
+      'Unsupported SSH message $messageId at packet '
+      '${_remotePacketSN.value}',
+    );
+    printTrace?.call('-> $socket: $message');
+    sendPacket(message.encode());
   }
 
   /// Records the extensions advertised by the peer in SSH_MSG_EXT_INFO.

--- a/test/src/ssh_transport_aead_test.dart
+++ b/test/src/ssh_transport_aead_test.dart
@@ -83,6 +83,7 @@ void main() {
           setPrivate(receiver, '_serverCipherType', cipherType);
           setPrivate(receiver, '_remoteCipherKey', key);
           setPrivate(receiver, '_remoteIV', iv);
+          setPrivate(receiver, '_kexInProgress', false);
           setSequenceValue(receiver, '_remotePacketSN', 0);
 
           receiverSocket.addIncomingBytes(encryptedPacket);

--- a/test/src/ssh_transport_strict_kex_test.dart
+++ b/test/src/ssh_transport_strict_kex_test.dart
@@ -3,8 +3,11 @@ import 'dart:mirrors';
 import 'dart:typed_data';
 
 import 'package:dartssh2/dartssh2.dart';
+import 'package:dartssh2/src/message/msg_debug.dart';
 import 'package:dartssh2/src/message/msg_ext_info.dart';
+import 'package:dartssh2/src/message/msg_ignore.dart';
 import 'package:dartssh2/src/message/msg_kex.dart';
+import 'package:dartssh2/src/message/msg_unimplemented.dart';
 import 'package:dartssh2/src/ssh_packet.dart';
 import 'package:test/test.dart';
 
@@ -236,10 +239,14 @@ void main() {
   });
 
   group('Strict key exchange message filtering', () {
-    for (final entry in {
-      'SSH_MSG_IGNORE': 2,
-      'SSH_MSG_UNIMPLEMENTED': 3,
-      'SSH_MSG_DEBUG': 4,
+    for (final entry in <String, Uint8List>{
+      'SSH_MSG_IGNORE': SSH_Message_Ignore.empty().encode(),
+      'SSH_MSG_UNIMPLEMENTED': SSH_Message_Unimplemented(0).encode(),
+      'SSH_MSG_DEBUG': SSH_Message_Debug(
+        alwaysDisplay: false,
+        message: Uint8List(0),
+        language: Uint8List(0),
+      ).encode(),
     }.entries) {
       test('rejects ${entry.key} during key exchange', () async {
         final socket = _CaptureSSHSocket();
@@ -250,7 +257,7 @@ void main() {
 
         await expectLater(
           invokePrivate(transport, '_handleMessage', [
-            Uint8List.fromList([entry.value, 0, 0, 0, 0])
+            entry.value,
           ]),
           throwsA(isA<SSHHandshakeError>()),
         );
@@ -266,7 +273,7 @@ void main() {
         setPrivate(transport, '_kexInProgress', false);
 
         await invokePrivate(transport, '_handleMessage', [
-          Uint8List.fromList([entry.value, 0, 0, 0, 0])
+          entry.value,
         ]);
 
         transport.close();
@@ -280,7 +287,7 @@ void main() {
         setPrivate(transport, '_kexInProgress', true);
 
         await invokePrivate(transport, '_handleMessage', [
-          Uint8List.fromList([entry.value, 0, 0, 0, 0])
+          entry.value,
         ]);
 
         transport.close();

--- a/test/src/ssh_transport_unimplemented_test.dart
+++ b/test/src/ssh_transport_unimplemented_test.dart
@@ -1,0 +1,297 @@
+import 'dart:async';
+import 'dart:mirrors';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:dartssh2/src/message/msg_debug.dart';
+import 'package:dartssh2/src/message/msg_ignore.dart';
+import 'package:dartssh2/src/message/msg_unimplemented.dart';
+import 'package:dartssh2/src/ssh_packet.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final transportLibrary = reflectClass(SSHTransport).owner as LibraryMirror;
+  final packetLibrary = reflectClass(SSHPacketSN).owner as LibraryMirror;
+
+  Symbol privateSymbol(String name) =>
+      MirrorSystem.getSymbol(name, transportLibrary);
+  Symbol packetPrivateSymbol(String name) =>
+      MirrorSystem.getSymbol(name, packetLibrary);
+
+  void setPrivate(SSHTransport transport, String field, Object? value) {
+    reflect(transport).setField(privateSymbol(field), value);
+  }
+
+  void setSequenceValue(SSHTransport transport, int value) {
+    final sequence =
+        reflect(transport).getField(privateSymbol('_remotePacketSN')).reflectee;
+    reflect(sequence).setField(packetPrivateSymbol('_value'), value);
+  }
+
+  Future<void> invokeHandleMessage(
+    SSHTransport transport,
+    Uint8List message,
+  ) async {
+    final result = reflect(transport).invoke(
+      privateSymbol('_handleMessage'),
+      [message],
+    );
+    final value = result.reflectee;
+    if (value is Future) await value;
+  }
+
+  Future<void> invokeProcessPackets(SSHTransport transport) async {
+    final result = reflect(transport).invoke(
+      privateSymbol('_processPackets'),
+      const [],
+    );
+    final value = result.reflectee;
+    if (value is Future) await value;
+  }
+
+  dynamic packetBuffer(SSHTransport transport) {
+    return reflect(transport).getField(privateSymbol('_buffer')).reflectee;
+  }
+
+  Uint8List clearTextPacket(Uint8List payload) {
+    return SSHPacket.pack(payload, align: SSHPacket.minAlign);
+  }
+
+  Uint8List packetPayload(Uint8List packet) {
+    final paddingLength = SSHPacket.readPaddingLength(packet);
+    return Uint8List.sublistView(
+      packet,
+      SSHPacket.headerLength,
+      packet.length - paddingLength,
+    );
+  }
+
+  SSH_Message_Unimplemented sentUnimplemented(Uint8List packet) {
+    return SSH_Message_Unimplemented.decode(packetPayload(packet));
+  }
+
+  group('SSH_MSG_UNIMPLEMENTED encoding', () {
+    test('round-trips the rejected packet sequence number', () {
+      final message = SSH_Message_Unimplemented(0xffffffff);
+
+      final decoded = SSH_Message_Unimplemented.decode(message.encode());
+
+      expect(decoded.sequenceNumber, 0xffffffff);
+      expect(decoded.toString(), contains('4294967295'));
+    });
+  });
+
+  group('SSH_MSG_UNIMPLEMENTED dispatch', () {
+    test('replies to an unrecognized message with its receive sequence',
+        () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(
+        socket,
+        onMessage: (_) => false,
+      );
+      socket.packets.clear();
+      setPrivate(transport, '_kexInProgress', false);
+      setSequenceValue(transport, 37);
+
+      await invokeHandleMessage(transport, Uint8List.fromList([255]));
+
+      expect(socket.packets, hasLength(1));
+      expect(sentUnimplemented(socket.packets.single).sequenceNumber, 37);
+
+      await transport.close();
+    });
+
+    test('does not reply when the upper layer handles the message', () async {
+      final socket = _CaptureSSHSocket();
+      final received = <Uint8List>[];
+      final transport = SSHTransport(
+        socket,
+        onMessage: (message) {
+          received.add(message);
+          return true;
+        },
+      );
+      socket.packets.clear();
+      setPrivate(transport, '_kexInProgress', false);
+      final channelData = Uint8List.fromList([94, 1, 2, 3]);
+
+      await invokeHandleMessage(transport, channelData);
+
+      expect(received, [channelData]);
+      expect(socket.packets, isEmpty);
+
+      await transport.close();
+    });
+
+    test('keeps the legacy packet callback behavior', () async {
+      final socket = _CaptureSSHSocket();
+      final received = <Uint8List>[];
+      final transport = SSHTransport(socket, onPacket: received.add);
+      socket.packets.clear();
+      setPrivate(transport, '_kexInProgress', false);
+      final extensionMessage = Uint8List.fromList([200, 1, 2, 3]);
+
+      await invokeHandleMessage(transport, extensionMessage);
+
+      expect(received, [extensionMessage]);
+      expect(socket.packets, isEmpty);
+
+      await transport.close();
+    });
+
+    test('does not reply to recognized generic transport messages', () async {
+      final socket = _CaptureSSHSocket();
+      var upperLayerCalls = 0;
+      final transport = SSHTransport(
+        socket,
+        onMessage: (_) {
+          upperLayerCalls++;
+          return false;
+        },
+      );
+      socket.packets.clear();
+      setPrivate(transport, '_kexInProgress', false);
+
+      final messages = [
+        SSH_Message_Ignore.empty().encode(),
+        SSH_Message_Debug(
+          alwaysDisplay: false,
+          message: Uint8List.fromList('diagnostic'.codeUnits),
+          language: Uint8List(0),
+        ).encode(),
+        SSH_Message_Unimplemented(12).encode(),
+      ];
+      for (final message in messages) {
+        await invokeHandleMessage(transport, message);
+      }
+
+      expect(upperLayerCalls, 0);
+      expect(socket.packets, isEmpty);
+
+      await transport.close();
+    });
+
+    test('uses the original sequence number for consecutive packets', () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(
+        socket,
+        onMessage: (_) => false,
+      );
+      socket.packets.clear();
+      setPrivate(transport, '_kexInProgress', false);
+      setSequenceValue(transport, 41);
+
+      final buffer = packetBuffer(transport);
+      buffer.add(clearTextPacket(Uint8List.fromList([200])));
+      buffer.add(clearTextPacket(Uint8List.fromList([201])));
+
+      await invokeProcessPackets(transport);
+
+      expect(socket.packets, hasLength(2));
+      expect(
+        socket.packets
+            .map(sentUnimplemented)
+            .map((message) => message.sequenceNumber),
+        [41, 42],
+      );
+
+      await transport.close();
+    });
+
+    test('rejects an unknown message during the initial strict key exchange',
+        () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket, onMessage: (_) => false);
+      socket.packets.clear();
+      setPrivate(transport, '_strictKex', true);
+      setPrivate(transport, '_isFirstKex', true);
+      setPrivate(transport, '_kexInProgress', true);
+
+      await expectLater(
+        invokeHandleMessage(transport, Uint8List.fromList([255])),
+        throwsA(isA<SSHHandshakeError>()),
+      );
+      expect(socket.packets, isEmpty);
+
+      await transport.close();
+    });
+
+    test('replies to an unknown message during a strict rekey', () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket, onMessage: (_) => false);
+      socket.packets.clear();
+      setPrivate(transport, '_strictKex', true);
+      setPrivate(transport, '_isFirstKex', false);
+      setPrivate(transport, '_kexInProgress', true);
+      setSequenceValue(transport, 9);
+
+      await invokeHandleMessage(transport, Uint8List.fromList([255]));
+
+      expect(socket.packets, hasLength(1));
+      expect(sentUnimplemented(socket.packets.single).sequenceNumber, 9);
+
+      await transport.close();
+    });
+  });
+}
+
+class _CaptureSSHSocket implements SSHSocket {
+  final _inputController = StreamController<Uint8List>();
+  final _doneCompleter = Completer<void>();
+  final packets = <Uint8List>[];
+
+  @override
+  Stream<Uint8List> get stream => _inputController.stream;
+
+  @override
+  StreamSink<List<int>> get sink => _CaptureSink(packets);
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  @override
+  Future<void> close() async {
+    if (!_doneCompleter.isCompleted) {
+      _doneCompleter.complete();
+    }
+    await _inputController.close();
+  }
+
+  @override
+  void destroy() {
+    if (!_doneCompleter.isCompleted) {
+      _doneCompleter.complete();
+    }
+    unawaited(_inputController.close());
+  }
+
+  @override
+  Future<void> flush() async {}
+}
+
+class _CaptureSink implements StreamSink<List<int>> {
+  _CaptureSink(this._packets);
+
+  final List<Uint8List> _packets;
+
+  @override
+  void add(List<int> data) {
+    _packets.add(Uint8List.fromList(data));
+  }
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) async {
+    await for (final chunk in stream) {
+      add(chunk);
+    }
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> get done async {}
+}


### PR DESCRIPTION
## Summary

- add encoding and decoding support for `SSH_MSG_UNIMPLEMENTED`
- report only genuinely unrecognized messages and include the rejected packet's original receive sequence number
- consume `SSH_MSG_IGNORE`, `SSH_MSG_DEBUG`, and incoming `SSH_MSG_UNIMPLEMENTED` without creating reply loops
- match OpenSSH behavior by disconnecting on unexpected messages during the initial strict key exchange while replying during non-strict exchanges and rekeys
- preserve the legacy `onPacket` callback behavior while allowing the client dispatcher to report whether a message was handled

## Testing

- `dart analyze`
- `dart test` (479 tests passed)