### PR TITLE
Add OpenSSH ChaCha20-Poly1305 packet cipher

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,11 +735,10 @@ void main() async {
 - `diffie-hellman-group1-sha1 `
   
 **Cipher**: 
+- `chacha20-poly1305@openssh.com`
 - `aes[128|256]-gcm@openssh.com`
 - `aes[128|192|256]-ctr`
 - `aes[128|192|256]-cbc`
-
-`chacha20-poly1305@openssh.com` is not supported yet.
 
 **Integrity**: 
 - `hmac-sha2-[256|512]-etm@openssh.com`
@@ -758,7 +757,7 @@ option and keep the weaker ones only as a fallback for old servers:
 |---|---|
 | **Key exchange** | curve25519 → ECDH NIST → DH group-exchange/group14 SHA-256 → the SHA-1 variants |
 | **Host key** | `ssh-ed25519` → `rsa-sha2-512/256` → ECDSA → `ssh-rsa` |
-| **Cipher** | AES-GCM → AES-CTR → AES-CBC |
+| **Cipher** | AES-GCM → ChaCha20-Poly1305 → AES-CTR → AES-CBC |
 | **Integrity** | ETM variants → `hmac-sha2-256/512` → `hmac-sha1` |
 
 Three groups are implemented but **left out of the defaults**, because they are

--- a/lib/src/algorithm/ssh_cipher_type.dart
+++ b/lib/src/algorithm/ssh_cipher_type.dart
@@ -7,6 +7,7 @@ class SSHCipherType extends SSHAlgorithm {
   static const values = [
     aes128gcm,
     aes256gcm,
+    chacha20poly1305,
     aes128cbc,
     aes192cbc,
     aes256cbc,
@@ -48,6 +49,15 @@ class SSHCipherType extends SSHAlgorithm {
     isAead: true,
     ivSize: 12,
     blockSize: 16,
+    aeadTagSize: 16,
+  );
+
+  static const chacha20poly1305 = SSHCipherType._(
+    name: 'chacha20-poly1305@openssh.com',
+    keySize: 64,
+    isAead: true,
+    ivSize: 0,
+    blockSize: 8,
     aeadTagSize: 16,
   );
 

--- a/lib/src/ssh_algorithm.dart
+++ b/lib/src/ssh_algorithm.dart
@@ -81,6 +81,7 @@ class SSHAlgorithms {
     this.cipher = const [
       SSHCipherType.aes256gcm,
       SSHCipherType.aes128gcm,
+      SSHCipherType.chacha20poly1305,
       SSHCipherType.aes256ctr,
       SSHCipherType.aes128ctr,
       // CBC in SSH is vulnerable to the plaintext-recovery attack described in

--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -19,6 +19,7 @@ import 'package:dartssh2/src/ssh_packet.dart';
 import 'package:dartssh2/src/utils/int.dart';
 import 'package:dartssh2/src/hostkey/hostkey_ed25519.dart';
 import 'package:dartssh2/src/utils/list.dart';
+import 'package:dartssh2/src/utils/openssh_chacha20_poly1305.dart';
 import 'package:dartssh2/src/message/msg_ext_info.dart';
 import 'package:dartssh2/src/message/msg_kex.dart';
 import 'package:dartssh2/src/message/msg_kex_dh.dart';
@@ -180,11 +181,23 @@ class SSHTransport {
   /// The decryption cipher algorithm type selected for server-to-client communication.
   SSHCipherType? _serverCipherType;
 
+  /// Cipher currently active for packets sent to the other side.
+  SSHCipherType? _localCipherType;
+
+  /// Cipher currently active for packets received from the other side.
+  SSHCipherType? _remoteCipherType;
+
   /// The MAC algorithm type selected for client-to-server integrity verification.
   SSHMacType? _clientMacType;
 
   /// The MAC algorithm type selected for server-to-client integrity verification.
   SSHMacType? _serverMacType;
+
+  /// MAC currently active for packets sent to the other side.
+  SSHMacType? _localMacType;
+
+  /// MAC currently active for packets received from the other side.
+  SSHMacType? _remoteMacType;
 
   /// The active key exchange algorithm implementation instance.
   SSHKex? _kex;
@@ -214,6 +227,12 @@ class SSHTransport {
 
   /// A [BlockCipher] to decrypt data sent from the other side.
   BlockCipher? _decryptCipher;
+
+  /// OpenSSH ChaCha20-Poly1305 context for packets sent to the other side.
+  OpenSSHChaCha20Poly1305? _localChaChaCipher;
+
+  /// OpenSSH ChaCha20-Poly1305 context for packets received from the other side.
+  OpenSSHChaCha20Poly1305? _remoteChaChaCipher;
 
   /// The cipher key derived for encrypting outgoing data.
   Uint8List? _localCipherKey;
@@ -316,10 +335,16 @@ class SSHTransport {
     }
 
     // Check if encryption is enabled and if we have MAC types initialized
-    final clientMacType = _clientMacType;
-    final serverMacType = _serverMacType;
-    final macType = isClient ? clientMacType : serverMacType;
-    final localCipherType = isClient ? _clientCipherType : _serverCipherType;
+    final macType = _localMacType;
+    final localCipherType = _localCipherType;
+
+    final localChaChaCipher = _localChaChaCipher;
+    if (localCipherType == SSHCipherType.chacha20poly1305 &&
+        localChaChaCipher != null) {
+      _sendChaChaPacket(data, localChaChaCipher);
+      _localPacketSN.increase();
+      return;
+    }
 
     if (localCipherType != null &&
         localCipherType.isAead &&
@@ -420,6 +445,29 @@ class SSHTransport {
     }
 
     _localPacketSN.increase();
+  }
+
+  /// Sends a packet using the OpenSSH ChaCha20-Poly1305 construction.
+  void _sendChaChaPacket(
+    Uint8List data,
+    OpenSSHChaCha20Poly1305 cipher,
+  ) {
+    final paddingLength = _alignedPaddingLength(
+      data.length,
+      OpenSSHChaCha20Poly1305.blockSize,
+    );
+    final packetLength = 1 + data.length + paddingLength;
+    final packet = Uint8List(4 + packetLength);
+    ByteData.sublistView(packet, 0, 4).setUint32(0, packetLength);
+    packet[4] = paddingLength;
+    packet.setRange(5, 5 + data.length, data);
+    packet.setRange(
+      5 + data.length,
+      packet.length,
+      randomBytes(paddingLength),
+    );
+
+    socket.sink.add(cipher.encryptPacket(packet, _localPacketSN.value));
   }
 
   /// Sends a packet encrypted using AEAD (e.g. AES-GCM).
@@ -658,9 +706,77 @@ class SSHTransport {
   /// WITHOUT `packet length`, `padding length`, `padding` and `MAC`. Returns
   /// `null` if there is not enough data in the buffer to read the packet.
   Uint8List? _consumePacket() {
+    if (_remoteCipherType == SSHCipherType.chacha20poly1305 &&
+        _remoteChaChaCipher != null) {
+      return _consumeChaChaPacket();
+    }
     return (_decryptCipher == null && _remoteCipherKey == null)
         ? _consumeClearTextPacket()
         : _consumeEncryptedPacket();
+  }
+
+  /// Consumes and decrypts one OpenSSH ChaCha20-Poly1305 packet.
+  Uint8List? _consumeChaChaPacket() {
+    if (_buffer.length < OpenSSHChaCha20Poly1305.encryptedLengthSize) {
+      return null;
+    }
+
+    final cipher = _remoteChaChaCipher!;
+    final packetLength = cipher.decryptPacketLength(
+      _buffer.view(0, OpenSSHChaCha20Poly1305.encryptedLengthSize),
+      _remotePacketSN.value,
+    );
+    _verifyPacketLength(packetLength);
+    if (packetLength < 5) {
+      throw SSHPacketError('Packet too short: $packetLength');
+    }
+    if (packetLength % OpenSSHChaCha20Poly1305.blockSize != 0) {
+      throw SSHPacketError(
+        'Invalid packet alignment: $packetLength is not a multiple of '
+        '${OpenSSHChaCha20Poly1305.blockSize}',
+      );
+    }
+
+    final encryptedPacketLength = OpenSSHChaCha20Poly1305.encryptedLengthSize +
+        packetLength +
+        OpenSSHChaCha20Poly1305.tagSize;
+    if (_buffer.length < encryptedPacketLength) {
+      return null;
+    }
+
+    late Uint8List packet;
+    try {
+      packet = cipher.decryptPacket(
+        _buffer.view(0, encryptedPacketLength),
+        _remotePacketSN.value,
+      );
+    } on InvalidCipherTextException {
+      throw SSHPacketError('AEAD authentication failed');
+    }
+    _buffer.consume(encryptedPacketLength);
+
+    if (SSHPacket.readPacketLength(packet) != packetLength) {
+      throw SSHPacketError('Decrypted packet length changed unexpectedly');
+    }
+    final paddingLength = SSHPacket.readPaddingLength(packet);
+    final payloadLength = packetLength - paddingLength - 1;
+    if (payloadLength < 0) {
+      throw SSHPacketError(
+        'Invalid padding length: $paddingLength for packet length $packetLength',
+      );
+    }
+
+    final minimumPaddingLength = _alignedPaddingLength(
+      payloadLength,
+      OpenSSHChaCha20Poly1305.blockSize,
+    );
+    if (paddingLength < minimumPaddingLength) {
+      throw SSHPacketError(
+        'Invalid padding length: $paddingLength, expected: $minimumPaddingLength',
+      );
+    }
+
+    return Uint8List.sublistView(packet, 5, 5 + payloadLength);
   }
 
   /// Consumes and returns a single unencrypted packet payload from the buffer.
@@ -690,7 +806,7 @@ class SSHTransport {
   Uint8List? _consumeEncryptedPacket() {
     printDebug?.call('SSHTransport._consumeEncryptedPacket');
 
-    final remoteCipherType = isClient ? _serverCipherType : _clientCipherType;
+    final remoteCipherType = _remoteCipherType;
     if (remoteCipherType != null &&
         remoteCipherType.isAead &&
         _remoteCipherKey != null &&
@@ -703,7 +819,7 @@ class SSHTransport {
       return null;
     }
 
-    final macType = isClient ? _serverMacType! : _clientMacType!;
+    final macType = _remoteMacType!;
     final isEtm = macType.isEtm;
     final macLength = _remoteMac!.macSize;
 
@@ -937,25 +1053,48 @@ class SSHTransport {
     final cipherType = isClient ? _clientCipherType : _serverCipherType;
     if (cipherType == null) throw StateError('No cipher type selected');
 
-    _localCipherKey = _deriveKey(
-      isClient ? SSHDeriveKeyType.clientKey : SSHDeriveKeyType.serverKey,
-      cipherType.keySize,
-    );
-    _localIV = _deriveKey(
-      isClient ? SSHDeriveKeyType.clientIV : SSHDeriveKeyType.serverIV,
-      cipherType.ivSize,
-    );
+    if (cipherType == SSHCipherType.chacha20poly1305) {
+      final key = _deriveKey(
+        isClient ? SSHDeriveKeyType.clientKey : SSHDeriveKeyType.serverKey,
+        OpenSSHChaCha20Poly1305.keySize,
+      );
+      final chachaCipher = OpenSSHChaCha20Poly1305(key);
 
-    if (cipherType.isAead) {
+      _localCipherType = cipherType;
+      _localMacType = null;
+      _localChaChaCipher = chachaCipher;
+      _localCipherKey = null;
+      _localIV = null;
       _encryptCipher = null;
       _localMac = null;
       _localAeadPacketCount = 0;
       return;
     }
 
-    _encryptCipher = cipherType.createCipher(
-      _localCipherKey!,
-      _localIV!,
+    final cipherKey = _deriveKey(
+      isClient ? SSHDeriveKeyType.clientKey : SSHDeriveKeyType.serverKey,
+      cipherType.keySize,
+    );
+    final iv = _deriveKey(
+      isClient ? SSHDeriveKeyType.clientIV : SSHDeriveKeyType.serverIV,
+      cipherType.ivSize,
+    );
+
+    if (cipherType.isAead) {
+      _localCipherType = cipherType;
+      _localMacType = null;
+      _localChaChaCipher = null;
+      _localCipherKey = cipherKey;
+      _localIV = iv;
+      _encryptCipher = null;
+      _localMac = null;
+      _localAeadPacketCount = 0;
+      return;
+    }
+
+    final encryptCipher = cipherType.createCipher(
+      cipherKey,
+      iv,
       forEncryption: true,
     );
 
@@ -966,8 +1105,16 @@ class SSHTransport {
       isClient ? SSHDeriveKeyType.clientMacKey : SSHDeriveKeyType.serverMacKey,
       macType.keySize,
     );
+    final mac = macType.createMac(macKey);
 
-    _localMac = macType.createMac(macKey);
+    _localCipherType = cipherType;
+    _localMacType = macType;
+    _localChaChaCipher = null;
+    _localCipherKey = cipherKey;
+    _localIV = iv;
+    _encryptCipher = encryptCipher;
+    _localMac = mac;
+    _localAeadPacketCount = 0;
   }
 
   /// Derives and applies the decryption and MAC keys for remote-to-local communication.
@@ -975,25 +1122,48 @@ class SSHTransport {
     final cipherType = isClient ? _serverCipherType : _clientCipherType;
     if (cipherType == null) throw StateError('No cipher type selected');
 
-    _remoteCipherKey = _deriveKey(
-      isClient ? SSHDeriveKeyType.serverKey : SSHDeriveKeyType.clientKey,
-      cipherType.keySize,
-    );
-    _remoteIV = _deriveKey(
-      isClient ? SSHDeriveKeyType.serverIV : SSHDeriveKeyType.clientIV,
-      cipherType.ivSize,
-    );
+    if (cipherType == SSHCipherType.chacha20poly1305) {
+      final key = _deriveKey(
+        isClient ? SSHDeriveKeyType.serverKey : SSHDeriveKeyType.clientKey,
+        OpenSSHChaCha20Poly1305.keySize,
+      );
+      final chachaCipher = OpenSSHChaCha20Poly1305(key);
 
-    if (cipherType.isAead) {
+      _remoteCipherType = cipherType;
+      _remoteMacType = null;
+      _remoteChaChaCipher = chachaCipher;
+      _remoteCipherKey = null;
+      _remoteIV = null;
       _decryptCipher = null;
       _remoteMac = null;
       _remoteAeadPacketCount = 0;
       return;
     }
 
-    _decryptCipher = cipherType.createCipher(
-      _remoteCipherKey!,
-      _remoteIV!,
+    final cipherKey = _deriveKey(
+      isClient ? SSHDeriveKeyType.serverKey : SSHDeriveKeyType.clientKey,
+      cipherType.keySize,
+    );
+    final iv = _deriveKey(
+      isClient ? SSHDeriveKeyType.serverIV : SSHDeriveKeyType.clientIV,
+      cipherType.ivSize,
+    );
+
+    if (cipherType.isAead) {
+      _remoteCipherType = cipherType;
+      _remoteMacType = null;
+      _remoteChaChaCipher = null;
+      _remoteCipherKey = cipherKey;
+      _remoteIV = iv;
+      _decryptCipher = null;
+      _remoteMac = null;
+      _remoteAeadPacketCount = 0;
+      return;
+    }
+
+    final decryptCipher = cipherType.createCipher(
+      cipherKey,
+      iv,
       forEncryption: false,
     );
 
@@ -1004,7 +1174,16 @@ class SSHTransport {
       isClient ? SSHDeriveKeyType.serverMacKey : SSHDeriveKeyType.clientMacKey,
       macType.keySize,
     );
-    _remoteMac = macType.createMac(macKey);
+    final mac = macType.createMac(macKey);
+
+    _remoteCipherType = cipherType;
+    _remoteMacType = macType;
+    _remoteChaChaCipher = null;
+    _remoteCipherKey = cipherKey;
+    _remoteIV = iv;
+    _decryptCipher = decryptCipher;
+    _remoteMac = mac;
+    _remoteAeadPacketCount = 0;
   }
 
   /// Derives a cryptographic key/IV of [keySize] bytes using KDF rules for the given [keyType].

--- a/lib/src/utils/openssh_chacha20_poly1305.dart
+++ b/lib/src/utils/openssh_chacha20_poly1305.dart
@@ -1,0 +1,210 @@
+import 'dart:typed_data';
+
+import 'package:dartssh2/src/utils/cipher_ext.dart';
+import 'package:pointycastle/export.dart';
+
+/// The packet cipher defined by `chacha20-poly1305@openssh.com`.
+///
+/// This is not the RFC 8439 AEAD construction. OpenSSH uses two independent
+/// ChaCha20 keys, encrypts the packet length separately, and authenticates the
+/// raw encrypted length and body with Poly1305.
+class OpenSSHChaCha20Poly1305 {
+  static const keySize = 64;
+  static const ivSize = 0;
+  static const blockSize = 8;
+  static const tagSize = 16;
+  static const encryptedLengthSize = 4;
+
+  OpenSSHChaCha20Poly1305(Uint8List keyMaterial) {
+    if (keyMaterial.length != keySize) {
+      throw ArgumentError.value(
+        keyMaterial.length,
+        'keyMaterial.length',
+        'OpenSSH ChaCha20-Poly1305 requires exactly $keySize bytes',
+      );
+    }
+
+    // PROTOCOL.chacha20poly1305 names these K_2 and K_1 respectively.
+    _payloadKey = Uint8List.fromList(keyMaterial.sublist(0, 32));
+    _lengthKey = Uint8List.fromList(keyMaterial.sublist(32, 64));
+  }
+
+  late final Uint8List _payloadKey;
+  late final Uint8List _lengthKey;
+
+  /// Encrypts `packet_length || padding_length || payload || padding`.
+  Uint8List encryptPacket(Uint8List packet, int sequenceNumber) {
+    if (packet.length < encryptedLengthSize) {
+      throw ArgumentError.value(
+        packet,
+        'packet',
+        'Packet must include a four-byte length field',
+      );
+    }
+
+    final nonce = _nonce(sequenceNumber);
+    final encryptedLength = _cryptLength(
+      Uint8List.sublistView(packet, 0, encryptedLengthSize),
+      nonce,
+    );
+
+    final payloadCipher = _payloadCipher(nonce);
+    final poly1305Key = _poly1305Key(payloadCipher);
+    final encryptedBody = Uint8List(packet.length - encryptedLengthSize);
+    payloadCipher.processBytes(
+      packet,
+      encryptedLengthSize,
+      encryptedBody.length,
+      encryptedBody,
+      0,
+    );
+
+    final tag = _authenticationTag(
+      encryptedLength,
+      encryptedBody,
+      poly1305Key,
+    );
+
+    return Uint8List(packet.length + tagSize)
+      ..setRange(0, encryptedLengthSize, encryptedLength)
+      ..setRange(
+        encryptedLengthSize,
+        packet.length,
+        encryptedBody,
+      )
+      ..setRange(packet.length, packet.length + tagSize, tag);
+  }
+
+  /// Decrypts the encrypted four-byte packet length without authenticating it.
+  ///
+  /// SSH needs this value to determine how many bytes belong to the packet.
+  /// Call [decryptPacket] before using any packet contents.
+  int decryptPacketLength(Uint8List encryptedLength, int sequenceNumber) {
+    if (encryptedLength.length < encryptedLengthSize) {
+      throw ArgumentError.value(
+        encryptedLength,
+        'encryptedLength',
+        'Encrypted packet length must contain at least four bytes',
+      );
+    }
+
+    final plaintext = _cryptLength(
+      Uint8List.sublistView(encryptedLength, 0, encryptedLengthSize),
+      _nonce(sequenceNumber),
+    );
+    return ByteData.sublistView(plaintext).getUint32(0);
+  }
+
+  /// Authenticates and decrypts a complete OpenSSH ChaCha20-Poly1305 packet.
+  ///
+  /// The returned bytes include the decrypted four-byte packet length. No
+  /// plaintext is returned unless the Poly1305 tag is valid.
+  Uint8List decryptPacket(Uint8List packet, int sequenceNumber) {
+    const minimumPacketSize = encryptedLengthSize + tagSize;
+    if (packet.length < minimumPacketSize) {
+      throw ArgumentError.value(
+        packet,
+        'packet',
+        'Encrypted packet is too short',
+      );
+    }
+
+    final ciphertextLength = packet.length - tagSize;
+    final encryptedLength = Uint8List.sublistView(
+      packet,
+      0,
+      encryptedLengthSize,
+    );
+    final encryptedBody = Uint8List.sublistView(
+      packet,
+      encryptedLengthSize,
+      ciphertextLength,
+    );
+    final actualTag = Uint8List.sublistView(packet, ciphertextLength);
+
+    final nonce = _nonce(sequenceNumber);
+    final payloadCipher = _payloadCipher(nonce);
+    final expectedTag = _authenticationTag(
+      encryptedLength,
+      encryptedBody,
+      _poly1305Key(payloadCipher),
+    );
+
+    if (!_constantTimeEquals(expectedTag, actualTag)) {
+      throw InvalidCipherTextException(
+        'OpenSSH ChaCha20-Poly1305 authentication failed',
+      );
+    }
+
+    final plaintextLength = _cryptLength(encryptedLength, nonce);
+    final plaintextBody = Uint8List(encryptedBody.length);
+    payloadCipher.processBytes(
+      encryptedBody,
+      0,
+      encryptedBody.length,
+      plaintextBody,
+      0,
+    );
+
+    return Uint8List(ciphertextLength)
+      ..setRange(0, encryptedLengthSize, plaintextLength)
+      ..setRange(encryptedLengthSize, ciphertextLength, plaintextBody);
+  }
+
+  Uint8List _cryptLength(Uint8List input, Uint8List nonce) {
+    final cipher = ChaCha20Engine()
+      ..init(true, ParametersWithIV(KeyParameter(_lengthKey), nonce));
+    final output = Uint8List(encryptedLengthSize);
+    cipher.processBytes(input, 0, encryptedLengthSize, output, 0);
+    return output;
+  }
+
+  ChaCha20Engine _payloadCipher(Uint8List nonce) {
+    return ChaCha20Engine()
+      ..init(true, ParametersWithIV(KeyParameter(_payloadKey), nonce));
+  }
+
+  Uint8List _poly1305Key(ChaCha20Engine cipher) {
+    // OpenSSH generates 32 key bytes at counter zero, then explicitly seeks
+    // to counter one for the packet body. Processing a full block here leaves
+    // PointyCastle at exactly the same counter-one position.
+    final firstBlock = Uint8List(64);
+    cipher.processBytes(firstBlock, 0, firstBlock.length, firstBlock, 0);
+    return Uint8List.sublistView(firstBlock, 0, 32);
+  }
+
+  Uint8List _authenticationTag(
+    Uint8List encryptedLength,
+    Uint8List encryptedBody,
+    Uint8List poly1305Key,
+  ) {
+    final mac = Poly1305()..init(KeyParameter(poly1305Key));
+    mac.updateAll(encryptedLength);
+    mac.updateAll(encryptedBody);
+    return mac.finish();
+  }
+
+  Uint8List _nonce(int sequenceNumber) {
+    if (sequenceNumber < 0 || sequenceNumber > 0xffffffff) {
+      throw RangeError.range(
+        sequenceNumber,
+        0,
+        0xffffffff,
+        'sequenceNumber',
+      );
+    }
+
+    final nonce = Uint8List(8);
+    ByteData.sublistView(nonce).setUint64(0, sequenceNumber);
+    return nonce;
+  }
+
+  bool _constantTimeEquals(Uint8List a, Uint8List b) {
+    if (a.length != b.length) return false;
+    var difference = 0;
+    for (var i = 0; i < a.length; i++) {
+      difference |= a[i] ^ b[i];
+    }
+    return difference == 0;
+  }
+}

--- a/test/src/algorithm/ssh_cipher_type_test.dart
+++ b/test/src/algorithm/ssh_cipher_type_test.dart
@@ -49,18 +49,37 @@ void main() {
       expect(SSHCipherType.aes128gcm.aeadTagSize, 16);
     });
 
-    test('AEAD ciphers do not expose BlockCipher API', () {
-      expect(
-        () => SSHCipherType.aes128gcm.createCipher(
-          Uint8List(SSHCipherType.aes128gcm.keySize),
-          Uint8List(SSHCipherType.aes128gcm.ivSize),
-          forEncryption: true,
-        ),
-        throwsA(isA<UnsupportedError>()),
-      );
+    test('OpenSSH ChaCha20-Poly1305 exposes packet-cipher metadata', () {
+      final cipher = SSHCipherType.chacha20poly1305;
+
+      expect(cipher.isAead, isTrue);
+      expect(cipher.keySize, 64);
+      expect(cipher.ivSize, 0);
+      expect(cipher.blockSize, 8);
+      expect(cipher.aeadTagSize, 16);
     });
 
-    test('fromName resolves AES-GCM ciphers', () {
+    test('AEAD ciphers do not expose BlockCipher API', () {
+      for (final cipher in [
+        SSHCipherType.chacha20poly1305,
+        SSHCipherType.aes128gcm,
+      ]) {
+        expect(
+          () => cipher.createCipher(
+            Uint8List(cipher.keySize),
+            Uint8List(cipher.ivSize),
+            forEncryption: true,
+          ),
+          throwsA(isA<UnsupportedError>()),
+        );
+      }
+    });
+
+    test('fromName resolves AEAD ciphers', () {
+      expect(
+        SSHCipherType.fromName('chacha20-poly1305@openssh.com'),
+        SSHCipherType.chacha20poly1305,
+      );
       expect(
         SSHCipherType.fromName('aes128-gcm@openssh.com'),
         SSHCipherType.aes128gcm,
@@ -133,6 +152,7 @@ void main() {
         equals([
           SSHCipherType.aes256gcm,
           SSHCipherType.aes128gcm,
+          SSHCipherType.chacha20poly1305,
           SSHCipherType.aes256ctr,
           SSHCipherType.aes128ctr,
           SSHCipherType.aes256cbc,

--- a/test/src/ssh_client_test.dart
+++ b/test/src/ssh_client_test.dart
@@ -17,6 +17,16 @@ void main() {
       client.close();
     });
 
+    test('chacha20-poly1305 works against a ssh server', () async {
+      final client = await getHoneypotClient(
+        algorithms: const SSHAlgorithms(
+          cipher: [SSHCipherType.chacha20poly1305],
+        ),
+      );
+      await client.authenticated;
+      client.close();
+    });
+
     test('onVerifyHostKey is called with OpenSSH-style SHA256 fingerprint',
         () async {
       var verifyCalled = false;

--- a/test/src/ssh_transport_aead_test.dart
+++ b/test/src/ssh_transport_aead_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:dartssh2/dartssh2.dart';
 import 'package:dartssh2/src/message/msg_kex.dart';
 import 'package:dartssh2/src/ssh_packet.dart';
+import 'package:dartssh2/src/utils/openssh_chacha20_poly1305.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -29,6 +30,320 @@ void main() {
   }
 
   group('SSHTransport AEAD', () {
+    test('exchanges fragmented OpenSSH ChaCha20-Poly1305 packets', () async {
+      final key = Uint8List.fromList(List<int>.generate(64, (i) => i));
+      final payload = Uint8List.fromList(
+        List<int>.generate(37, (i) => (i * 17) & 0xff),
+      );
+
+      final senderSocket = _CaptureSSHSocket();
+      final sender = SSHTransport(
+        senderSocket,
+        algorithms: const SSHAlgorithms(
+          cipher: [SSHCipherType.chacha20poly1305],
+        ),
+      );
+      setPrivate(
+        sender,
+        '_clientCipherType',
+        SSHCipherType.chacha20poly1305,
+      );
+      setPrivate(
+        sender,
+        '_localCipherType',
+        SSHCipherType.chacha20poly1305,
+      );
+      setPrivate(
+        sender,
+        '_localChaChaCipher',
+        OpenSSHChaCha20Poly1305(key),
+      );
+      setPrivate(sender, '_kexInProgress', false);
+      setSequenceValue(sender, '_localPacketSN', 7);
+
+      sender.sendPacket(payload);
+      final encryptedPacket = senderSocket.packets.last;
+
+      final receiverSocket = _CaptureSSHSocket();
+      final receivedPacket = Completer<Uint8List>();
+      final receiver = SSHTransport(
+        receiverSocket,
+        algorithms: const SSHAlgorithms(
+          cipher: [SSHCipherType.chacha20poly1305],
+        ),
+        onPacket: (packet) {
+          if (!receivedPacket.isCompleted) {
+            receivedPacket.complete(packet);
+          }
+        },
+      );
+      setPrivate(receiver, '_remoteVersion', 'SSH-2.0-test');
+      setPrivate(
+        receiver,
+        '_serverCipherType',
+        SSHCipherType.chacha20poly1305,
+      );
+      setPrivate(
+        receiver,
+        '_remoteCipherType',
+        SSHCipherType.chacha20poly1305,
+      );
+      setPrivate(
+        receiver,
+        '_remoteChaChaCipher',
+        OpenSSHChaCha20Poly1305(key),
+      );
+      setSequenceValue(receiver, '_remotePacketSN', 7);
+
+      receiverSocket.addIncomingBytes(
+        Uint8List.sublistView(encryptedPacket, 0, 4),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(receivedPacket.isCompleted, isFalse);
+
+      receiverSocket.addIncomingBytes(
+        Uint8List.sublistView(encryptedPacket, 4),
+      );
+      expect(
+        await receivedPacket.future.timeout(const Duration(seconds: 2)),
+        payload,
+      );
+
+      sender.close();
+      receiver.close();
+    });
+
+    test('keeps active ChaCha keys until NEWKEYS takes effect', () {
+      final key = Uint8List.fromList(List<int>.generate(64, (i) => i));
+      final cipher = OpenSSHChaCha20Poly1305(key);
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      // A rekey has selected AES-GCM, but outbound packets up to and including
+      // NEWKEYS must still use the currently active ChaCha keys.
+      setPrivate(
+        transport,
+        '_clientCipherType',
+        SSHCipherType.aes128gcm,
+      );
+      setPrivate(
+        transport,
+        '_localCipherType',
+        SSHCipherType.chacha20poly1305,
+      );
+      setPrivate(transport, '_localChaChaCipher', cipher);
+      setPrivate(transport, '_kexInProgress', true);
+      setSequenceValue(transport, '_localPacketSN', 9);
+
+      final payload = Uint8List.fromList([SSH_Message_NewKeys.messageId]);
+      transport.sendPacket(payload);
+
+      final encrypted = socket.packets.last;
+      final packet = cipher.decryptPacket(encrypted, 9);
+      final packetLength = SSHPacket.readPacketLength(packet);
+      final paddingLength = SSHPacket.readPaddingLength(packet);
+      expect(
+        Uint8List.sublistView(packet, 5, 4 + packetLength - paddingLength),
+        payload,
+      );
+
+      // The inbound direction likewise keeps using its active cipher while a
+      // different negotiated cipher waits for the peer's NEWKEYS packet.
+      final receiverSocket = _CaptureSSHSocket();
+      final receiver = SSHTransport(receiverSocket);
+      setPrivate(
+        receiver,
+        '_serverCipherType',
+        SSHCipherType.aes128gcm,
+      );
+      setPrivate(
+        receiver,
+        '_remoteCipherType',
+        SSHCipherType.chacha20poly1305,
+      );
+      setPrivate(receiver, '_remoteChaChaCipher', cipher);
+      setSequenceValue(receiver, '_remotePacketSN', 9);
+      final dynamic buffer = getPrivate<dynamic>(receiver, '_buffer');
+      buffer.add(encrypted);
+
+      final received = reflect(receiver)
+          .invoke(privateSymbol('_consumeChaChaPacket'), const []).reflectee;
+      expect(received, payload);
+
+      transport.close();
+      receiver.close();
+    });
+
+    test('rejects misaligned OpenSSH ChaCha20-Poly1305 packets', () {
+      final key = Uint8List(64);
+      final cipher = OpenSSHChaCha20Poly1305(key);
+      final packet = Uint8List(4 + 15);
+      ByteData.sublistView(packet, 0, 4).setUint32(0, 15);
+      packet[4] = 4;
+
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+      setPrivate(
+        transport,
+        '_serverCipherType',
+        SSHCipherType.chacha20poly1305,
+      );
+      setPrivate(
+        transport,
+        '_remoteCipherType',
+        SSHCipherType.chacha20poly1305,
+      );
+      setPrivate(transport, '_remoteChaChaCipher', cipher);
+      final dynamic buffer = getPrivate<dynamic>(transport, '_buffer');
+      buffer.add(cipher.encryptPacket(packet, 0));
+
+      expect(
+        () => reflect(transport).invoke(
+          privateSymbol('_consumeChaChaPacket'),
+          const [],
+        ),
+        throwsA(
+          isA<SSHPacketError>().having(
+            (error) => error.toString(),
+            'message',
+            contains('Invalid packet alignment'),
+          ),
+        ),
+      );
+
+      transport.close();
+    });
+
+    test('rekey replaces ChaCha contexts and switching clears them', () {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      setPrivate(transport, '_kexType', SSHKexType.x25519);
+      setPrivate(transport, '_sharedSecret', BigInt.from(21));
+      setPrivate(
+        transport,
+        '_exchangeHash',
+        Uint8List.fromList(List<int>.filled(32, 22)),
+      );
+      setPrivate(
+        transport,
+        '_sessionId',
+        Uint8List.fromList(List<int>.filled(32, 23)),
+      );
+      setPrivate(
+        transport,
+        '_clientCipherType',
+        SSHCipherType.chacha20poly1305,
+      );
+
+      reflect(transport).invoke(privateSymbol('_applyLocalKeys'), const []);
+      final first = getPrivate<OpenSSHChaCha20Poly1305?>(
+        transport,
+        '_localChaChaCipher',
+      );
+      expect(first, isNotNull);
+      expect(
+        getPrivate<SSHCipherType?>(transport, '_localCipherType'),
+        SSHCipherType.chacha20poly1305,
+      );
+      expect(getPrivate<Object?>(transport, '_localMacType'), isNull);
+      expect(getPrivate<Object?>(transport, '_localCipherKey'), isNull);
+      expect(getPrivate<Object?>(transport, '_localIV'), isNull);
+
+      setPrivate(transport, '_sharedSecret', BigInt.from(24));
+      reflect(transport).invoke(privateSymbol('_applyLocalKeys'), const []);
+      final second = getPrivate<OpenSSHChaCha20Poly1305?>(
+        transport,
+        '_localChaChaCipher',
+      );
+      expect(second, isNotNull);
+      expect(identical(second, first), isFalse);
+
+      setPrivate(transport, '_clientCipherType', SSHCipherType.aes128ctr);
+      setPrivate(transport, '_clientMacType', SSHMacType.hmacSha256);
+      reflect(transport).invoke(privateSymbol('_applyLocalKeys'), const []);
+      expect(
+        getPrivate<Object?>(transport, '_localChaChaCipher'),
+        isNull,
+      );
+      expect(
+        getPrivate<SSHCipherType?>(transport, '_localCipherType'),
+        SSHCipherType.aes128ctr,
+      );
+      expect(
+        getPrivate<SSHMacType?>(transport, '_localMacType'),
+        SSHMacType.hmacSha256,
+      );
+      expect(getPrivate<Object?>(transport, '_encryptCipher'), isNotNull);
+
+      transport.close();
+    });
+
+    test('remote rekey replaces the ChaCha context', () {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+
+      setPrivate(transport, '_kexType', SSHKexType.x25519);
+      setPrivate(transport, '_sharedSecret', BigInt.from(31));
+      setPrivate(
+        transport,
+        '_exchangeHash',
+        Uint8List.fromList(List<int>.filled(32, 32)),
+      );
+      setPrivate(
+        transport,
+        '_sessionId',
+        Uint8List.fromList(List<int>.filled(32, 33)),
+      );
+      setPrivate(
+        transport,
+        '_serverCipherType',
+        SSHCipherType.chacha20poly1305,
+      );
+
+      reflect(transport).invoke(privateSymbol('_applyRemoteKeys'), const []);
+      final first = getPrivate<OpenSSHChaCha20Poly1305?>(
+        transport,
+        '_remoteChaChaCipher',
+      );
+      expect(first, isNotNull);
+
+      setPrivate(transport, '_sharedSecret', BigInt.from(34));
+      reflect(transport).invoke(privateSymbol('_applyRemoteKeys'), const []);
+      final second = getPrivate<OpenSSHChaCha20Poly1305?>(
+        transport,
+        '_remoteChaChaCipher',
+      );
+      expect(second, isNotNull);
+      expect(identical(second, first), isFalse);
+      expect(
+        getPrivate<SSHCipherType?>(transport, '_remoteCipherType'),
+        SSHCipherType.chacha20poly1305,
+      );
+      expect(getPrivate<Object?>(transport, '_remoteMacType'), isNull);
+      expect(getPrivate<Object?>(transport, '_remoteCipherKey'), isNull);
+      expect(getPrivate<Object?>(transport, '_remoteIV'), isNull);
+
+      setPrivate(transport, '_serverCipherType', SSHCipherType.aes128ctr);
+      setPrivate(transport, '_serverMacType', SSHMacType.hmacSha256);
+      reflect(transport).invoke(privateSymbol('_applyRemoteKeys'), const []);
+      expect(
+        getPrivate<Object?>(transport, '_remoteChaChaCipher'),
+        isNull,
+      );
+      expect(
+        getPrivate<SSHCipherType?>(transport, '_remoteCipherType'),
+        SSHCipherType.aes128ctr,
+      );
+      expect(
+        getPrivate<SSHMacType?>(transport, '_remoteMacType'),
+        SSHMacType.hmacSha256,
+      );
+      expect(getPrivate<Object?>(transport, '_decryptCipher'), isNotNull);
+
+      transport.close();
+    });
+
     test('exchanges packets with AES-GCM', () async {
       for (final cipherType in [
         SSHCipherType.aes128gcm,
@@ -53,6 +368,7 @@ void main() {
           );
 
           setPrivate(sender, '_clientCipherType', cipherType);
+          setPrivate(sender, '_localCipherType', cipherType);
           setPrivate(sender, '_localCipherKey', key);
           setPrivate(sender, '_localIV', iv);
           setPrivate(sender, '_kexInProgress', false);
@@ -81,6 +397,7 @@ void main() {
 
           setPrivate(receiver, '_remoteVersion', 'SSH-2.0-test');
           setPrivate(receiver, '_serverCipherType', cipherType);
+          setPrivate(receiver, '_remoteCipherType', cipherType);
           setPrivate(receiver, '_remoteCipherKey', key);
           setPrivate(receiver, '_remoteIV', iv);
           setSequenceValue(receiver, '_remotePacketSN', 0);
@@ -121,6 +438,7 @@ void main() {
         );
 
         setPrivate(sender, '_clientCipherType', cipherType);
+        setPrivate(sender, '_localCipherType', cipherType);
         setPrivate(sender, '_localCipherKey', key);
         setPrivate(sender, '_localIV', iv);
         setPrivate(sender, '_kexInProgress', false);
@@ -140,6 +458,7 @@ void main() {
 
         setPrivate(receiver, '_remoteVersion', 'SSH-2.0-test');
         setPrivate(receiver, '_serverCipherType', cipherType);
+        setPrivate(receiver, '_remoteCipherType', cipherType);
         setPrivate(receiver, '_remoteCipherKey', key);
         setPrivate(receiver, '_remoteIV', iv);
         setSequenceValue(receiver, '_remotePacketSN', 0);
@@ -313,6 +632,7 @@ void main() {
 
     test('kexinit allows missing MAC when AEAD cipher is selected', () async {
       for (final cipherType in [
+        SSHCipherType.chacha20poly1305,
         SSHCipherType.aes128gcm,
         SSHCipherType.aes256gcm
       ]) {

--- a/test/src/utils/openssh_chacha20_poly1305_test.dart
+++ b/test/src/utils/openssh_chacha20_poly1305_test.dart
@@ -1,0 +1,110 @@
+import 'dart:typed_data';
+
+import 'package:convert/convert.dart';
+import 'package:dartssh2/src/utils/openssh_chacha20_poly1305.dart';
+import 'package:pointycastle/export.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OpenSSHChaCha20Poly1305', () {
+    final key = Uint8List.fromList(List<int>.generate(64, (i) => i));
+    // Fixed packet vector derived from OpenSSH 10.5's cipher-chachapoly.c:
+    // K_2 is bytes 0..31, K_1 is bytes 32..63, and seqnr is 0x01020304.
+    final plaintext = _bytes(
+      '00000010'
+      '04'
+      '68656c6c6f20776f726c64'
+      '00010203',
+    );
+    final ciphertext = _bytes(
+      'bc79806b'
+      '92aa79deb77e06debb1f4898a8415877'
+      '75aca6b6c01a2037e45c6712ba973d9b',
+    );
+    const sequenceNumber = 0x01020304;
+
+    test('matches the OpenSSH packet construction', () {
+      final cipher = OpenSSHChaCha20Poly1305(key);
+
+      expect(
+        cipher.encryptPacket(plaintext, sequenceNumber),
+        ciphertext,
+      );
+      expect(
+        cipher.decryptPacketLength(ciphertext, sequenceNumber),
+        16,
+      );
+      expect(
+        cipher.decryptPacket(ciphertext, sequenceNumber),
+        plaintext,
+      );
+    });
+
+    test('copies key material on construction', () {
+      final mutableKey = Uint8List.fromList(key);
+      final cipher = OpenSSHChaCha20Poly1305(mutableKey);
+      mutableKey.fillRange(0, mutableKey.length, 0xff);
+
+      expect(
+        cipher.encryptPacket(plaintext, sequenceNumber),
+        ciphertext,
+      );
+    });
+
+    test('rejects changes to encrypted length, body, or tag', () {
+      final cipher = OpenSSHChaCha20Poly1305(key);
+
+      for (final index in [0, 4, ciphertext.length - 1]) {
+        final tampered = Uint8List.fromList(ciphertext);
+        tampered[index] ^= 1;
+
+        expect(
+          () => cipher.decryptPacket(tampered, sequenceNumber),
+          throwsA(isA<InvalidCipherTextException>()),
+        );
+      }
+    });
+
+    test('uses the packet sequence number as part of the nonce', () {
+      final cipher = OpenSSHChaCha20Poly1305(key);
+
+      final first = cipher.encryptPacket(plaintext, 0);
+      final second = cipher.encryptPacket(plaintext, 1);
+
+      expect(second, isNot(first));
+      expect(cipher.decryptPacket(first, 0), plaintext);
+      expect(cipher.decryptPacket(second, 1), plaintext);
+    });
+
+    test('validates key, packet, and sequence number lengths', () {
+      expect(
+        () => OpenSSHChaCha20Poly1305(Uint8List(63)),
+        throwsArgumentError,
+      );
+
+      final cipher = OpenSSHChaCha20Poly1305(key);
+      expect(
+        () => cipher.encryptPacket(Uint8List(3), 0),
+        throwsArgumentError,
+      );
+      expect(
+        () => cipher.decryptPacketLength(Uint8List(3), 0),
+        throwsArgumentError,
+      );
+      expect(
+        () => cipher.decryptPacket(Uint8List(19), 0),
+        throwsArgumentError,
+      );
+      expect(
+        () => cipher.encryptPacket(plaintext, -1),
+        throwsRangeError,
+      );
+      expect(
+        () => cipher.encryptPacket(plaintext, 0x100000000),
+        throwsRangeError,
+      );
+    });
+  });
+}
+
+Uint8List _bytes(String value) => Uint8List.fromList(hex.decode(value));


### PR DESCRIPTION
## Summary

- add a dedicated `chacha20-poly1305@openssh.com` packet cipher instead of modeling it as RFC 8439 AEAD
- match OpenSSH's 64-byte K_2/K_1 key layout, encrypted packet length, big-endian sequence-number nonce, counter-one payload stream, and raw Poly1305 input
- keep negotiated and active cipher/MAC state separate so rekeys continue using the old keys through `SSH_MSG_NEWKEYS`
- advertise the correct 64-byte key, zero-byte IV, 8-byte block, and 16-byte tag metadata while preserving the existing AES-GCM preference
- document the newly supported cipher

## Validation

- fixed packet vector derived from OpenSSH 10.5 `cipher-chachapoly.c`
- encrypted-length, packet-body, and tag tampering tests
- fragmented receive, packet alignment, directional rekey, and cipher-switch tests
- live SSH connection forced to `chacha20-poly1305@openssh.com`
- `dart analyze`
- `dart test` (483 tests passed)