### PR TITLE
Add hostbased authentication and methodsLeft handling

### DIFF
--- a/lib/src/message/msg_userauth.dart
+++ b/lib/src/message/msg_userauth.dart
@@ -23,10 +23,17 @@ class SSH_Message_Userauth_Request extends SSHMessage {
   final Uint8List? publicKey;
   final Uint8List? signature;
 
-  /* 'publickey' method specific fields */
+  /* 'keyboard-interactive' method specific fields */
 
   final String? languageTag;
   final String? submethods;
+
+  /* 'hostbased' method specific fields */
+
+  final String? hostKeyAlgorithm;
+  final Uint8List? hostKey;
+  final String? clientHostName;
+  final String? clientUsername;
 
   SSH_Message_Userauth_Request({
     required this.user,
@@ -39,6 +46,10 @@ class SSH_Message_Userauth_Request extends SSHMessage {
     this.signature,
     this.languageTag,
     this.submethods,
+    this.hostKeyAlgorithm,
+    this.hostKey,
+    this.clientHostName,
+    this.clientUsername,
   });
 
   factory SSH_Message_Userauth_Request.password({
@@ -98,6 +109,27 @@ class SSH_Message_Userauth_Request extends SSHMessage {
       languageTag: languageTag,
       submethods: submethods,
       methodName: 'keyboard-interactive',
+    );
+  }
+
+  factory SSH_Message_Userauth_Request.hostbased({
+    required String username,
+    required String hostKeyAlgorithm,
+    required Uint8List hostKey,
+    required String clientHostName,
+    required String clientUsername,
+    required Uint8List signature,
+    String serviceName = 'ssh-connection',
+  }) {
+    return SSH_Message_Userauth_Request(
+      serviceName: serviceName,
+      user: username,
+      methodName: 'hostbased',
+      hostKeyAlgorithm: hostKeyAlgorithm,
+      hostKey: hostKey,
+      clientHostName: clientHostName,
+      clientUsername: clientUsername,
+      signature: signature,
     );
   }
 
@@ -161,6 +193,16 @@ class SSH_Message_Userauth_Request extends SSHMessage {
           languageTag: languageTag,
           submethods: submethods,
         );
+      case 'hostbased':
+        return SSH_Message_Userauth_Request.hostbased(
+          username: user,
+          serviceName: serviceName,
+          hostKeyAlgorithm: reader.readUtf8(),
+          hostKey: reader.readString(),
+          clientHostName: reader.readUtf8(),
+          clientUsername: reader.readUtf8(),
+          signature: reader.readString(),
+        );
       case 'none':
         return SSH_Message_Userauth_Request.none(
           user: user,
@@ -198,6 +240,13 @@ class SSH_Message_Userauth_Request extends SSHMessage {
       case 'keyboard-interactive':
         writer.writeUtf8(languageTag!);
         writer.writeUtf8(submethods!);
+        break;
+      case 'hostbased':
+        writer.writeUtf8(hostKeyAlgorithm!);
+        writer.writeString(hostKey!);
+        writer.writeUtf8(clientHostName!);
+        writer.writeUtf8(clientUsername!);
+        writer.writeString(signature!);
         break;
       case 'none':
         break;

--- a/lib/src/ssh_client.dart
+++ b/lib/src/ssh_client.dart
@@ -16,6 +16,7 @@ import 'package:dartssh2/src/ssh_identity.dart';
 import 'package:dartssh2/src/ssh_session.dart';
 import 'package:dartssh2/src/ssh_transport.dart';
 import 'package:dartssh2/src/utils/async_queue.dart';
+import 'package:dartssh2/src/utils/auth_methods.dart';
 import 'package:dartssh2/src/utils/pending_requests.dart';
 import 'package:dartssh2/src/utils/terminal_state.dart';
 import 'package:dartssh2/src/message/msg_channel.dart';
@@ -150,6 +151,18 @@ class SSHClient {
   /// authentication. Set this field to enable authentication with public key.
   final List<SSHIdentity>? identities;
 
+  /// Identities to use for RFC 4252 hostbased authentication.
+  ///
+  /// Unlike [identities], these represent keys belonging to the client host,
+  /// not the user logging in to the server.
+  final List<SSHIdentity>? hostbasedIdentities;
+
+  /// Fully qualified client host name sent during hostbased authentication.
+  final String? hostName;
+
+  /// Local account name sent during hostbased authentication.
+  final String? userNameOnClientHost;
+
   /// Set this field to enable the 'password' authentication method. Return null
   /// to skip to the next available authentication method.
   final SSHPasswordRequestHandler? onPasswordRequest;
@@ -217,6 +230,9 @@ class SSHClient {
     this.algorithms = const SSHAlgorithms(),
     this.onVerifyHostKey,
     this.identities,
+    this.hostbasedIdentities,
+    this.hostName,
+    this.userNameOnClientHost,
     this.onPasswordRequest,
     this.onChangePasswordRequest,
     this.onUserInfoRequest,
@@ -257,6 +273,10 @@ class SSHClient {
 
     if (identities != null) {
       _identitiesLeft.addAll(identities!);
+    }
+
+    if (hostbasedIdentities != null) {
+      _hostbasedIdentitiesLeft.addAll(hostbasedIdentities!);
     }
 
     final handshakeTimeout = this.handshakeTimeout;
@@ -310,7 +330,13 @@ class SSHClient {
 
   final _authMethodsLeft = Queue<SSHAuthMethod>();
 
+  final _preferredAuthMethods = <SSHAuthMethod>[];
+
+  final _exhaustedAuthMethods = <SSHAuthMethod>{};
+
   final _identitiesLeft = Queue<SSHIdentity>();
+
+  final _hostbasedIdentitiesLeft = Queue<SSHIdentity>();
 
   final _remoteForwards = <SSHRemoteForward>{};
 
@@ -940,6 +966,27 @@ class SSHClient {
     printTrace?.call('<- $socket: $message');
     printDebug?.call('SSHClient._handleUserauthFailure');
     _currentProbedIdentity = null;
+
+    if (message.partialSuccess) {
+      printDebug?.call(
+        'Authentication partially succeeded with '
+        '${_currentAuthMethod?.name}',
+      );
+      _resetAuthStateForNextFactor();
+    } else {
+      _markCurrentAuthMethodAttempted();
+    }
+
+    final continuableMethods = selectContinuableAuthMethods(
+      preferredMethods: _preferredAuthMethods,
+      serverMethods: message.methodsLeft,
+      availableMethods: _availableAuthMethods,
+      onNote: printDebug,
+    );
+    _authMethodsLeft
+      ..clear()
+      ..addAll(continuableMethods);
+
     _tryNextAuthMethod();
   }
 
@@ -997,7 +1044,10 @@ class SSHClient {
     printTrace?.call('<- $socket: $message');
 
     final response = await onChangePasswordRequest!(message.prompt);
-    if (response == null) return _tryNextAuthMethod();
+    if (response == null) {
+      _exhaustedAuthMethods.add(SSHAuthMethod.password);
+      return _tryNextAuthMethod();
+    }
 
     _sendMessage(SSH_Message_Userauth_Request.newPassword(
       user: username,
@@ -1015,7 +1065,10 @@ class SSHClient {
       SSHUserInfoRequest(message.name, message.instruction, message.prompts),
     );
 
-    if (responses == null) return _tryNextAuthMethod();
+    if (responses == null) {
+      _exhaustedAuthMethods.add(SSHAuthMethod.keyboardInteractive);
+      return _tryNextAuthMethod();
+    }
 
     if (responses.length != message.prompts.length) {
       throw ArgumentError(
@@ -1316,30 +1369,33 @@ class SSHClient {
     printDebug?.call('SSHClient._startAuthentication');
 
     if (identities != null && identities!.isNotEmpty) {
-      _authMethodsLeft.add(SSHAuthMethod.publicKey);
+      _preferredAuthMethods.add(SSHAuthMethod.publicKey);
     }
 
     if (onPasswordRequest != null) {
-      _authMethodsLeft.add(SSHAuthMethod.password);
+      _preferredAuthMethods.add(SSHAuthMethod.password);
     }
 
     if (onUserInfoRequest != null) {
-      _authMethodsLeft.add(SSHAuthMethod.keyboardInteractive);
+      _preferredAuthMethods.add(SSHAuthMethod.keyboardInteractive);
     }
 
-    _authMethodsLeft.add(SSHAuthMethod.none);
+    if (hostbasedIdentities != null &&
+        hostbasedIdentities!.isNotEmpty &&
+        hostName != null &&
+        userNameOnClientHost != null) {
+      _preferredAuthMethods.add(SSHAuthMethod.hostbased);
+    }
+
+    _authMethodsLeft
+      ..addAll(_preferredAuthMethods)
+      ..add(SSHAuthMethod.none);
 
     _tryNextAuthMethod();
   }
 
   void _tryNextAuthMethod() {
     printDebug?.call('SSHClient._tryNextAuthenticationMethod');
-
-    if (_currentAuthMethod == SSHAuthMethod.publicKey) {
-      if (_identitiesLeft.isNotEmpty) {
-        return _catch(() => _authWithNextPublicKey());
-      }
-    }
 
     if (_authMethodsLeft.isEmpty) {
       return _authenticated.completeError(
@@ -1360,6 +1416,8 @@ class SSHClient {
         return _catch(() => _authWithNextPublicKey());
       case SSHAuthMethod.keyboardInteractive:
         return _authWithKeyboardInteractive();
+      case SSHAuthMethod.hostbased:
+        return _catch(() => _authWithNextHostbased());
     }
   }
 
@@ -1373,6 +1431,7 @@ class SSHClient {
 
     final password = await onPasswordRequest!();
     if (password == null) {
+      _exhaustedAuthMethods.add(SSHAuthMethod.password);
       _tryNextAuthMethod();
       return;
     }
@@ -1384,6 +1443,12 @@ class SSHClient {
 
   Future<void> _authWithNextPublicKey() async {
     printDebug?.call('SSHClient._authWithPublicKey');
+
+    if (_identitiesLeft.isEmpty) {
+      _exhaustedAuthMethods.add(SSHAuthMethod.publicKey);
+      _tryNextAuthMethod();
+      return;
+    }
 
     final identity = _identitiesLeft.removeFirst();
     final publicKey = identity.toPublicKey();
@@ -1433,6 +1498,90 @@ class SSHClient {
     _sendMessage(
       SSH_Message_Userauth_Request.keyboardInteractive(user: username),
     );
+  }
+
+  Future<void> _authWithNextHostbased() async {
+    printDebug?.call('SSHClient._authWithHostbased');
+
+    if (_hostbasedIdentitiesLeft.isEmpty) {
+      _exhaustedAuthMethods.add(SSHAuthMethod.hostbased);
+      _tryNextAuthMethod();
+      return;
+    }
+
+    final identity = _hostbasedIdentitiesLeft.removeFirst();
+    final hostKey = identity.toPublicKey().encode();
+    final challenge = _transport.composeHostbasedChallenge(
+      username: username,
+      service: 'ssh-connection',
+      hostKeyAlgorithm: identity.type,
+      hostKey: hostKey,
+      clientHostName: hostName!,
+      clientUsername: userNameOnClientHost!,
+    );
+    final signature = await identity.sign(challenge);
+
+    if (isClosed || _currentAuthMethod != SSHAuthMethod.hostbased) {
+      return;
+    }
+
+    _sendMessage(
+      SSH_Message_Userauth_Request.hostbased(
+        username: username,
+        hostKeyAlgorithm: identity.type,
+        hostKey: hostKey,
+        clientHostName: hostName!,
+        clientUsername: userNameOnClientHost!,
+        signature: signature.encode(),
+      ),
+    );
+  }
+
+  Set<SSHAuthMethod> get _availableAuthMethods => {
+        if (_identitiesLeft.isNotEmpty) SSHAuthMethod.publicKey,
+        if (!_exhaustedAuthMethods.contains(SSHAuthMethod.password) &&
+            onPasswordRequest != null)
+          SSHAuthMethod.password,
+        if (!_exhaustedAuthMethods
+                .contains(SSHAuthMethod.keyboardInteractive) &&
+            onUserInfoRequest != null)
+          SSHAuthMethod.keyboardInteractive,
+        if (_hostbasedIdentitiesLeft.isNotEmpty &&
+            hostName != null &&
+            userNameOnClientHost != null)
+          SSHAuthMethod.hostbased,
+      };
+
+  void _markCurrentAuthMethodAttempted() {
+    switch (_currentAuthMethod) {
+      case SSHAuthMethod.password:
+      case SSHAuthMethod.keyboardInteractive:
+      case SSHAuthMethod.none:
+        _exhaustedAuthMethods.add(_currentAuthMethod!);
+        break;
+      case SSHAuthMethod.publicKey:
+        if (_identitiesLeft.isEmpty) {
+          _exhaustedAuthMethods.add(SSHAuthMethod.publicKey);
+        }
+        break;
+      case SSHAuthMethod.hostbased:
+        if (_hostbasedIdentitiesLeft.isEmpty) {
+          _exhaustedAuthMethods.add(SSHAuthMethod.hostbased);
+        }
+        break;
+      case null:
+        break;
+    }
+  }
+
+  void _resetAuthStateForNextFactor() {
+    _exhaustedAuthMethods.clear();
+    // OpenSSH resets public-key attempt state after partial success so the
+    // next authentication factor may use publickey again. Hostbased keys are
+    // consumed as they are tried and are intentionally not replenished.
+    _identitiesLeft
+      ..clear()
+      ..addAll(identities ?? const <SSHIdentity>[]);
   }
 
   Future<SSHChannelController> _openSessionChannel() {

--- a/lib/src/ssh_identity.dart
+++ b/lib/src/ssh_identity.dart
@@ -14,8 +14,12 @@ abstract class SSHIdentity {
   /// Base constructor for custom [SSHIdentity] implementations.
   SSHIdentity();
 
-  /// The key type or algorithm name (e.g. `ssh-ed25519`, `ssh-rsa`,
-  /// `ecdsa-sha2-nistp256`).
+  /// The signature/public-key algorithm name used for authentication (e.g.
+  /// `ssh-ed25519`, `rsa-sha2-256`, `ecdsa-sha2-nistp256`).
+  ///
+  /// This can differ from the type encoded in [toPublicKey]. For example, an
+  /// RSA identity may use `rsa-sha2-256` here while its key blob starts with
+  /// `ssh-rsa` (RFC 8332).
   String get type;
 
   /// Optional comment or human-readable label associated with this identity

--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -1038,6 +1038,28 @@ class SSHTransport {
     return writer.takeBytes();
   }
 
+  /// Composes the RFC 4252 hostbased authentication data to be signed.
+  Uint8List composeHostbasedChallenge({
+    required String username,
+    required String service,
+    required String hostKeyAlgorithm,
+    required Uint8List hostKey,
+    required String clientHostName,
+    required String clientUsername,
+  }) {
+    final writer = SSHMessageWriter();
+    writer.writeString(sessionId!);
+    writer.writeUint8(SSH_Message_Userauth_Request.messageId);
+    writer.writeUtf8(username);
+    writer.writeUtf8(service);
+    writer.writeUtf8('hostbased');
+    writer.writeUtf8(hostKeyAlgorithm);
+    writer.writeString(hostKey);
+    writer.writeUtf8(clientHostName);
+    writer.writeUtf8(clientUsername);
+    return writer.takeBytes();
+  }
+
   /// Verifies the server's public host key signature against the computed exchange hash.
   bool _verifyHostkey({
     required Uint8List keyBytes,

--- a/lib/src/ssh_userauth.dart
+++ b/lib/src/ssh_userauth.dart
@@ -3,7 +3,7 @@ enum SSHAuthMethod {
   password,
   publicKey,
   keyboardInteractive,
-  // hostbased,
+  hostbased,
 }
 
 extension SSHAuthMethodX on SSHAuthMethod {
@@ -17,6 +17,8 @@ extension SSHAuthMethodX on SSHAuthMethod {
         return 'publickey';
       case SSHAuthMethod.keyboardInteractive:
         return 'keyboard-interactive';
+      case SSHAuthMethod.hostbased:
+        return 'hostbased';
     }
   }
 }

--- a/lib/src/utils/auth_methods.dart
+++ b/lib/src/utils/auth_methods.dart
@@ -1,0 +1,42 @@
+import 'package:dartssh2/src/ssh_userauth.dart';
+
+/// Selects the authentication methods that may productively continue.
+///
+/// [serverMethods] is an allow-list, not a preference list. The returned order
+/// therefore follows [preferredMethods], matching OpenSSH's handling of
+/// `PreferredAuthentications`.
+List<SSHAuthMethod> selectContinuableAuthMethods({
+  required Iterable<SSHAuthMethod> preferredMethods,
+  required Iterable<String> serverMethods,
+  required Set<SSHAuthMethod> availableMethods,
+  void Function(String message)? onNote,
+}) {
+  final supportedNames = <String>{};
+
+  for (final name in serverMethods) {
+    final method = _methodFromName(name);
+    if (method == null) {
+      onNote?.call('Unknown authentication method from server: $name');
+      continue;
+    }
+    if (method == SSHAuthMethod.none) {
+      onNote?.call('Server listed "none" as a continuable auth method');
+      continue;
+    }
+    supportedNames.add(name);
+  }
+
+  return [
+    for (final method in preferredMethods)
+      if (availableMethods.contains(method) &&
+          supportedNames.contains(method.name))
+        method,
+  ];
+}
+
+SSHAuthMethod? _methodFromName(String name) {
+  for (final method in SSHAuthMethod.values) {
+    if (method.name == name) return method;
+  }
+  return null;
+}

--- a/test/src/message/msg_userauth_test.dart
+++ b/test/src/message/msg_userauth_test.dart
@@ -90,11 +90,41 @@ void main() {
       expect(decoded.submethods, 'pam');
     });
 
+    test('hostbased follows the RFC 4252 field order', () {
+      final original = SSH_Message_Userauth_Request.hostbased(
+        username: 'remote-user',
+        hostKeyAlgorithm: 'rsa-sha2-512',
+        hostKey: publicKey,
+        clientHostName: 'client.example.com.',
+        clientUsername: 'local-user',
+        signature: signature,
+      );
+      final encoded = original.encode();
+      final reader = SSHMessageReader(encoded);
+
+      expect(reader.readUint8(), SSH_Message_Userauth_Request.messageId);
+      expect(reader.readUtf8(), 'remote-user');
+      expect(reader.readUtf8(), 'ssh-connection');
+      expect(reader.readUtf8(), 'hostbased');
+      expect(reader.readUtf8(), 'rsa-sha2-512');
+      expect(reader.readString(), publicKey);
+      expect(reader.readUtf8(), 'client.example.com.');
+      expect(reader.readUtf8(), 'local-user');
+      expect(reader.readString(), signature);
+
+      final decoded = SSH_Message_Userauth_Request.decode(encoded);
+      expect(decoded.hostKeyAlgorithm, 'rsa-sha2-512');
+      expect(decoded.hostKey, publicKey);
+      expect(decoded.clientHostName, 'client.example.com.');
+      expect(decoded.clientUsername, 'local-user');
+      expect(decoded.signature, signature);
+    });
+
     test('rejects an unknown method on encode and decode', () {
       final unknown = SSH_Message_Userauth_Request(
         user: 'demo',
         serviceName: 'ssh-connection',
-        methodName: 'hostbased',
+        methodName: 'gssapi-with-mic',
       );
 
       expect(unknown.encode, throwsUnimplementedError);
@@ -104,7 +134,7 @@ void main() {
       writer.writeUint8(SSH_Message_Userauth_Request.messageId);
       writer.writeUtf8('demo');
       writer.writeUtf8('ssh-connection');
-      writer.writeUtf8('hostbased');
+      writer.writeUtf8('gssapi-with-mic');
 
       expect(
         () => SSH_Message_Userauth_Request.decode(writer.takeBytes()),

--- a/test/src/ssh_identity_test.dart
+++ b/test/src/ssh_identity_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:dartssh2/dartssh2.dart';
 import 'package:dartssh2/src/message/msg_service.dart';
 import 'package:dartssh2/src/message/msg_userauth.dart';
+import 'package:dartssh2/src/ssh_message.dart';
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
@@ -413,6 +414,224 @@ void main() {
       );
 
       await Future<void>.delayed(Duration.zero);
+      await client.close();
+    });
+
+    test('hostbased signs the RFC 4252 challenge with an async identity',
+        () async {
+      final socket = _FakeSSHSocket();
+      final sessionId = Uint8List.fromList([1, 2, 3, 4]);
+      final hostKeyWriter = SSHMessageWriter()..writeUtf8('ssh-rsa');
+      final hostKey = hostKeyWriter.takeBytes();
+      late Uint8List signedChallenge;
+
+      final identity = SSHIdentity.custom(
+        type: 'rsa-sha2-512',
+        publicKey: SSHRawHostKey(hostKey),
+        signer: (challenge) async {
+          signedChallenge = challenge;
+          return SSHRawSignature(Uint8List.fromList([9, 8, 7]));
+        },
+      );
+      final client = SSHClient(
+        socket,
+        username: 'remote-user',
+        hostbasedIdentities: [identity],
+        hostName: 'client.example.com.',
+        userNameOnClientHost: 'local-user',
+      );
+      client.sessionId = sessionId;
+
+      client.handlePacket(SSH_Message_Service_Accept('ssh-userauth').encode());
+      await Future<void>.delayed(Duration.zero);
+
+      final reader = SSHMessageReader(signedChallenge);
+      expect(reader.readString(), sessionId);
+      expect(reader.readUint8(), SSH_Message_Userauth_Request.messageId);
+      expect(reader.readUtf8(), 'remote-user');
+      expect(reader.readUtf8(), 'ssh-connection');
+      expect(reader.readUtf8(), 'hostbased');
+      expect(reader.readUtf8(), 'rsa-sha2-512');
+      expect(reader.readString(), hostKey);
+      expect(SSHHostKey.getType(hostKey), 'ssh-rsa');
+      expect(reader.readUtf8(), 'client.example.com.');
+      expect(reader.readUtf8(), 'local-user');
+
+      client.handlePacket(SSH_Message_Userauth_Success().encode());
+      await client.authenticated;
+      await client.close();
+    });
+
+    test('methodsLeft preserves client preference and drops exhausted keys',
+        () async {
+      final socket = _FakeSSHSocket();
+      final attempts = <String>[];
+      var passwordRequests = 0;
+
+      SSHIdentity identity(String name) => SSHIdentity.custom(
+            type: 'ssh-ed25519',
+            publicKey: SSHRawHostKey(Uint8List.fromList([name.length])),
+            signer: (challenge) {
+              attempts.add(name);
+              return SSHRawSignature(Uint8List.fromList([name.length]));
+            },
+          );
+
+      final client = SSHClient(
+        socket,
+        username: 'test-user',
+        identities: [identity('first'), identity('second')],
+        onPasswordRequest: () {
+          passwordRequests++;
+          return 'secret';
+        },
+      );
+      client.sessionId = Uint8List(32);
+
+      client.handlePacket(SSH_Message_Service_Accept('ssh-userauth').encode());
+      await Future<void>.delayed(Duration.zero);
+      expect(attempts, ['first']);
+
+      client.handlePacket(
+        SSH_Message_Userauth_Failure(
+          methodsLeft: const ['password', 'publickey'],
+        ).encode(),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(attempts, ['first', 'second']);
+      expect(passwordRequests, 0);
+
+      client.handlePacket(
+        SSH_Message_Userauth_Failure(
+          methodsLeft: const ['publickey', 'password'],
+        ).encode(),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(attempts, ['first', 'second']);
+      expect(passwordRequests, 1);
+
+      client.handlePacket(SSH_Message_Userauth_Success().encode());
+      await client.authenticated;
+      await client.close();
+    });
+
+    test('methodsLeft stops an identity method the server no longer allows',
+        () async {
+      final socket = _FakeSSHSocket();
+      final signedIdentities = <int>[];
+      var passwordRequests = 0;
+
+      SSHIdentity identity(int id) => SSHIdentity.custom(
+            type: 'ssh-ed25519',
+            publicKey: SSHRawHostKey(Uint8List.fromList([id])),
+            signer: (challenge) {
+              signedIdentities.add(id);
+              return SSHRawSignature(Uint8List.fromList([id]));
+            },
+          );
+
+      final client = SSHClient(
+        socket,
+        username: 'test-user',
+        identities: [identity(1), identity(2)],
+        onPasswordRequest: () {
+          passwordRequests++;
+          return 'secret';
+        },
+      );
+      client.sessionId = Uint8List(32);
+
+      client.handlePacket(SSH_Message_Service_Accept('ssh-userauth').encode());
+      await Future<void>.delayed(Duration.zero);
+      expect(signedIdentities, [1]);
+
+      client.handlePacket(
+        SSH_Message_Userauth_Failure(
+          methodsLeft: const ['password'],
+        ).encode(),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(signedIdentities, [1]);
+      expect(passwordRequests, 1);
+
+      client.handlePacket(SSH_Message_Userauth_Success().encode());
+      await client.authenticated;
+      await client.close();
+    });
+
+    test('hostbased remains available while an identity is untried', () async {
+      final socket = _FakeSSHSocket();
+      final attempts = <int>[];
+
+      SSHIdentity identity(int id) => SSHIdentity.custom(
+            type: 'ssh-ed25519',
+            publicKey: SSHRawHostKey(Uint8List.fromList([id])),
+            signer: (challenge) {
+              attempts.add(id);
+              return SSHRawSignature(Uint8List.fromList([id]));
+            },
+          );
+
+      final client = SSHClient(
+        socket,
+        username: 'remote-user',
+        hostbasedIdentities: [identity(1), identity(2)],
+        hostName: 'client.example.com.',
+        userNameOnClientHost: 'local-user',
+      );
+      client.sessionId = Uint8List(32);
+
+      client.handlePacket(SSH_Message_Service_Accept('ssh-userauth').encode());
+      await Future<void>.delayed(Duration.zero);
+      expect(attempts, [1]);
+
+      client.handlePacket(
+        SSH_Message_Userauth_Failure(
+          methodsLeft: const ['hostbased'],
+        ).encode(),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(attempts, [1, 2]);
+
+      client.handlePacket(SSH_Message_Userauth_Success().encode());
+      await client.authenticated;
+      await client.close();
+    });
+
+    test('partial success resets publickey identities for the next factor',
+        () async {
+      final socket = _FakeSSHSocket();
+      var signCount = 0;
+      final identity = SSHIdentity.custom(
+        type: 'ssh-ed25519',
+        publicKey: SSHRawHostKey(Uint8List.fromList([1, 2, 3])),
+        signer: (challenge) {
+          signCount++;
+          return SSHRawSignature(Uint8List.fromList([4, 5, 6]));
+        },
+      );
+      final client = SSHClient(
+        socket,
+        username: 'test-user',
+        identities: [identity],
+      );
+      client.sessionId = Uint8List(32);
+
+      client.handlePacket(SSH_Message_Service_Accept('ssh-userauth').encode());
+      await Future<void>.delayed(Duration.zero);
+      expect(signCount, 1);
+
+      client.handlePacket(
+        SSH_Message_Userauth_Failure(
+          methodsLeft: const ['publickey'],
+          partialSuccess: true,
+        ).encode(),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(signCount, 2);
+
+      client.handlePacket(SSH_Message_Userauth_Success().encode());
+      await client.authenticated;
       await client.close();
     });
   });

--- a/test/src/utils/auth_methods_test.dart
+++ b/test/src/utils/auth_methods_test.dart
@@ -1,0 +1,108 @@
+import 'package:dartssh2/src/ssh_userauth.dart';
+import 'package:dartssh2/src/utils/auth_methods.dart';
+import 'package:test/test.dart';
+
+void main() {
+  List<SSHAuthMethod> select({
+    required List<SSHAuthMethod> preferred,
+    required List<String> server,
+    required Set<SSHAuthMethod> available,
+    void Function(String)? onNote,
+  }) {
+    return selectContinuableAuthMethods(
+      preferredMethods: preferred,
+      serverMethods: server,
+      availableMethods: available,
+      onNote: onNote,
+    );
+  }
+
+  test('uses the server list as an allow-list, not a preference list', () {
+    expect(
+      select(
+        preferred: [
+          SSHAuthMethod.publicKey,
+          SSHAuthMethod.password,
+          SSHAuthMethod.keyboardInteractive,
+        ],
+        server: ['keyboard-interactive', 'password', 'publickey'],
+        available: {
+          SSHAuthMethod.publicKey,
+          SSHAuthMethod.password,
+          SSHAuthMethod.keyboardInteractive,
+        },
+      ),
+      [
+        SSHAuthMethod.publicKey,
+        SSHAuthMethod.password,
+        SSHAuthMethod.keyboardInteractive,
+      ],
+    );
+  });
+
+  test('drops methods that have no remaining client-side attempt', () {
+    expect(
+      select(
+        preferred: [
+          SSHAuthMethod.publicKey,
+          SSHAuthMethod.hostbased,
+          SSHAuthMethod.password,
+        ],
+        server: ['publickey', 'hostbased', 'password'],
+        available: {SSHAuthMethod.password},
+      ),
+      [SSHAuthMethod.password],
+    );
+  });
+
+  test('keeps identity methods while another identity remains', () {
+    expect(
+      select(
+        preferred: [
+          SSHAuthMethod.publicKey,
+          SSHAuthMethod.hostbased,
+          SSHAuthMethod.password,
+        ],
+        server: ['password', 'hostbased', 'publickey'],
+        available: {
+          SSHAuthMethod.publicKey,
+          SSHAuthMethod.hostbased,
+          SSHAuthMethod.password,
+        },
+      ),
+      [
+        SSHAuthMethod.publicKey,
+        SSHAuthMethod.hostbased,
+        SSHAuthMethod.password,
+      ],
+    );
+  });
+
+  test('does not duplicate a method repeated by the server', () {
+    expect(
+      select(
+        preferred: [SSHAuthMethod.publicKey, SSHAuthMethod.password],
+        server: ['publickey', 'publickey', 'password'],
+        available: {SSHAuthMethod.publicKey, SSHAuthMethod.password},
+      ),
+      [SSHAuthMethod.publicKey, SSHAuthMethod.password],
+    );
+  });
+
+  test('reports unknown and invalid continuable methods', () {
+    final notes = <String>[];
+
+    expect(
+      select(
+        preferred: SSHAuthMethod.values,
+        server: ['none', 'gssapi-with-mic'],
+        available: SSHAuthMethod.values.toSet(),
+        onNote: notes.add,
+      ),
+      isEmpty,
+    );
+    expect(notes, hasLength(2));
+    expect(notes[0], contains('none'));
+    expect(notes[1], contains('gssapi-with-mic'));
+  });
+}


### PR DESCRIPTION
## Summary

- add RFC 4252 hostbased authentication using the asynchronous `SSHIdentity` API
- keep the host key blob type separate from the authentication/signature algorithm, including RSA SHA-2
- treat `methodsLeft` as a server allow-list while preserving client authentication preference order
- retain publickey and hostbased only while identities remain, and reset publickey state after partial success like OpenSSH
- cover hostbased packet/challenge layout and authentication state transitions

## Testing

- `dart analyze`
- `dart test` (482 tests)