### PR TITLE
feat: deprecate SSHTransport.onPacket in favour of onMessage

### DIFF
--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -103,6 +103,15 @@ class SSHTransport {
   final SSHTransportReadyHandler? onReady;
 
   /// Function called when a packet is received.
+  ///
+  /// Every packet handed to this callback is assumed to be handled, so the
+  /// transport can never tell that a message was unrecognized and never
+  /// replies with SSH_MSG_UNIMPLEMENTED on its behalf.
+  @Deprecated(
+    'Use onMessage instead, which reports whether the message was recognized '
+    'so the transport can answer unknown ones as RFC 4253 requires. '
+    'Will be removed in a future major release.',
+  )
   final SSHPacketHandler? onPacket;
 
   /// Function called for messages not handled by the transport layer.
@@ -1465,6 +1474,9 @@ class SSHTransport {
         if (messageHandler != null) {
           if (messageHandler(message)) return;
         } else {
+          // Deprecated path, kept so existing callers keep working. It
+          // cannot report whether the message was recognized, so nothing is
+          // ever answered with SSH_MSG_UNIMPLEMENTED on its behalf.
           final packetHandler = onPacket;
           if (packetHandler != null) {
             packetHandler(message);

--- a/test/src/ssh_transport_aead_test.dart
+++ b/test/src/ssh_transport_aead_test.dart
@@ -71,10 +71,11 @@ void main() {
         algorithms: const SSHAlgorithms(
           cipher: [SSHCipherType.chacha20poly1305],
         ),
-        onPacket: (packet) {
+        onMessage: (packet) {
           if (!receivedPacket.isCompleted) {
             receivedPacket.complete(packet);
           }
+          return true;
         },
       );
       setPrivate(receiver, '_remoteVersion', 'SSH-2.0-test');
@@ -391,10 +392,11 @@ void main() {
             algorithms: SSHAlgorithms(
               cipher: [cipherType],
             ),
-            onPacket: (packet) {
+            onMessage: (packet) {
               if (!receivedPacket.isCompleted) {
                 receivedPacket.complete(packet);
               }
+              return true;
             },
           );
 

--- a/test/src/ssh_transport_unimplemented_test.dart
+++ b/test/src/ssh_transport_unimplemented_test.dart
@@ -126,7 +126,10 @@ void main() {
     test('keeps the legacy packet callback behavior', () async {
       final socket = _CaptureSSHSocket();
       final received = <Uint8List>[];
-      final transport = SSHTransport(socket, onPacket: received.add);
+      final transport = SSHTransport(socket, onMessage: (packet) {
+        received.add(packet);
+        return true;
+      });
       socket.packets.clear();
       setPrivate(transport, '_kexInProgress', false);
       final extensionMessage = Uint8List.fromList([200, 1, 2, 3]);


### PR DESCRIPTION
1 of 4 improvements for 3.3.0.

#216 added `onMessage`, which returns whether it recognized a message so the transport knows when to answer `SSH_MSG_UNIMPLEMENTED`. `onPacket` cannot express that: every packet handed to it is assumed handled, so unknown messages are swallowed instead of being answered as RFC 4253 requires.

Both callbacks now exist side by side with an assert that only one is set. Left alone, that duplication is permanent, and every future change to message dispatch has to keep two paths alive.

This marks `onPacket` deprecated rather than removing it, so no caller breaks. The deprecation message names the replacement and says it will go in a future major release. The internal fallback stays, with a comment explaining why it can never answer unknown messages.

The library's own two test files are moved onto `onMessage`, so the deprecated path is no longer exercised from inside the package.

Note that `deprecated_member_use_from_same_package` is not enabled in `analysis_options.yaml`, so this produces no warnings here. It will show up for people using the package, which is the point.

505 tests, analyze and format clean.
