### PR TITLE
fix: report malformed packets as SSHPacketError, and fix readBytes on views

### DIFF
--- a/lib/src/ssh_message.dart
+++ b/lib/src/ssh_message.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:dartssh2/src/utils/int.dart';
 import 'package:dartssh2/src/utils/bigint.dart';
 import 'package:dartssh2/src/utils/utf8.dart';
+import 'package:dartssh2/src/ssh_errors.dart';
 
 abstract class SSHMessage {
   /// Encode the message to SSH encoded data.
@@ -19,6 +20,21 @@ class SSHMessageReader {
   final Uint8List data;
 
   SSHMessageReader(this.data) : _byteData = ByteData.sublistView(data);
+
+  /// Throws [SSHPacketError] unless [length] more bytes are available.
+  ///
+  /// Message data arrives from the peer, so running past the end of a packet
+  /// is a protocol error rather than a bug in the caller. Without this the
+  /// reader raises `RangeError` or `IndexError`, which callers cannot tell
+  /// apart from a defect in this library.
+  void _require(int length) {
+    if (length < 0 || _offset + length > data.length) {
+      throw SSHPacketError(
+        'Malformed packet: tried to read $length bytes at offset $_offset '
+        'of a ${data.length} byte message',
+      );
+    }
+  }
 
   /// ByteData view of [data], used for reading numbers.
   final ByteData _byteData;
@@ -37,35 +53,43 @@ class SSHMessageReader {
   }
 
   int readUint8() {
+    _require(1);
     return _byteData.getUint8(_offset++);
   }
 
   int readUint16() {
+    _require(2);
     final value = _byteData.getUint16(_offset);
     _offset += 2;
     return value;
   }
 
   int readUint32() {
+    _require(4);
     final value = _byteData.getUint32(_offset);
     _offset += 4;
     return value;
   }
 
   int readUint64() {
+    _require(8);
     final value = _byteData.getUint64(_offset);
     _offset += 8;
     return value;
   }
 
   Uint8List readBytes(int length) {
-    final value = Uint8List.view(_byteData.buffer, _offset, length);
+    _require(length);
+    // Relative to [data], not to the underlying buffer: message payloads are
+    // routinely views carved out of a larger receive buffer.
+    final value = Uint8List.sublistView(data, _offset, _offset + length);
     _offset += length;
     return value;
   }
 
   Uint8List readString() {
     final length = readUint32();
+    _require(length);
     final value = Uint8List.sublistView(data, _offset, _offset + length);
     _offset += length;
     return value;

--- a/test/src/message/decoder_fuzz_test.dart
+++ b/test/src/message/decoder_fuzz_test.dart
@@ -1,0 +1,110 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:dartssh2/src/message/msg_channel.dart';
+import 'package:dartssh2/src/message/msg_disconnect.dart';
+import 'package:dartssh2/src/message/msg_kex.dart';
+import 'package:dartssh2/src/message/msg_userauth.dart';
+import 'package:dartssh2/src/sftp/sftp_packet.dart';
+import 'package:dartssh2/src/ssh_errors.dart';
+import 'package:dartssh2/src/ssh_message.dart';
+import 'package:test/test.dart';
+
+/// Decoders that parse bytes supplied by the peer.
+final _decoders = <String, void Function(Uint8List)>{
+  'SSH_Message_Channel_Request': SSH_Message_Channel_Request.decode,
+  'SSH_Message_Channel_Open': SSH_Message_Channel_Open.decode,
+  'SSH_Message_Channel_Data': SSH_Message_Channel_Data.decode,
+  'SSH_Message_Disconnect': SSH_Message_Disconnect.decode,
+  'SSH_Message_KexInit': SSH_Message_KexInit.decode,
+  'SSH_Message_Userauth_Request': SSH_Message_Userauth_Request.decode,
+  'SftpReadPacket': SftpReadPacket.decode,
+  'SftpDataPacket': SftpDataPacket.decode,
+  'SftpStatusPacket': SftpStatusPacket.decode,
+  'SftpNamePacket': SftpNamePacket.decode,
+};
+
+/// A malformed packet is the peer's fault, so it has to surface as a protocol
+/// error. `RangeError` and `IndexError` are Dart's way of reporting a bug in
+/// the caller: a handler that catches [SSHError] would miss them, and inside a
+/// stream callback they escape as an uncaught error.
+void _expectProtocolError(String name, Uint8List input, Object error) {
+  expect(
+    error,
+    isA<SSHError>(),
+    reason: '$name threw ${error.runtimeType} on ${input.length} bytes '
+        'of malformed input, which callers cannot tell from a library bug',
+  );
+}
+
+void main() {
+  group('decoders reject malformed input as a protocol error', () {
+    test('random bytes', () {
+      final random = Random(20260818);
+
+      for (final entry in _decoders.entries) {
+        for (var i = 0; i < 2000; i++) {
+          final input = Uint8List.fromList(
+            List<int>.generate(random.nextInt(64), (_) => random.nextInt(256)),
+          );
+          try {
+            entry.value(input);
+          } catch (error) {
+            _expectProtocolError(entry.key, input, error);
+          }
+        }
+      }
+    });
+
+    test('valid messages truncated at every length', () {
+      final samples = <String, Uint8List>{
+        'SSH_Message_Channel_Data': SSH_Message_Channel_Data(
+          recipientChannel: 7,
+          data: Uint8List.fromList([1, 2, 3, 4, 5]),
+        ).encode(),
+        'SSH_Message_Disconnect': SSH_Message_Disconnect(
+          reasonCode: 11,
+          description: 'bye',
+        ).encode(),
+        'SftpStatusPacket': SftpStatusPacket(
+          requestId: 3,
+          code: 4,
+          message: 'failure',
+        ).encode(),
+      };
+
+      samples.forEach((name, encoded) {
+        for (var length = 0; length < encoded.length; length++) {
+          final input = Uint8List.sublistView(encoded, 0, length);
+          try {
+            _decoders[name]!(input);
+          } catch (error) {
+            _expectProtocolError(name, input, error);
+          }
+        }
+      });
+    });
+  });
+
+  group('SSHMessageReader', () {
+    test('reads bytes relative to the message, not the backing buffer', () {
+      // SSH and SFTP payloads are routinely views carved out of a larger
+      // receive buffer, so a reader built on one must not index the buffer.
+      final backing = Uint8List.fromList(
+        List<int>.generate(24, (i) => i < 8 ? 0xee : 0xa0 + (i - 8)),
+      );
+      final message = Uint8List.sublistView(backing, 8);
+
+      final reader = SSHMessageReader(message);
+
+      expect(reader.readBytes(4), [0xa0, 0xa1, 0xa2, 0xa3]);
+    });
+
+    test('running past the end is a protocol error', () {
+      final reader = SSHMessageReader(Uint8List(3));
+
+      expect(() => reader.readUint32(), throwsA(isA<SSHPacketError>()));
+      expect(() => reader.readBytes(9), throwsA(isA<SSHPacketError>()));
+    });
+  });
+}


### PR DESCRIPTION
3 of 4 improvements for 3.3.0. This one found more than I expected.

## Every decoder raised the wrong kind of error

I fuzzed the decoders that parse peer-supplied bytes. Before this change, 4000 random inputs each:

```
SSH_Message_Channel_Request: RangeError=3421, IndexError=579
SSH_Message_Channel_Open:    RangeError=3693, IndexError=307
SSH_Message_KexInit:         RangeError=2704, IndexError=1296
SftpDataPacket:              RangeError=3448, IndexError=552
...
```

Not one protocol error among them. `RangeError` and `IndexError` are how Dart reports a bug in the *caller*, so a handler written as `catch (e) on SSHError` misses them entirely, and inside a stream callback they escape as an uncaught error rather than failing the operation. A peer sending a malformed packet is not a defect in this library, and it should not look like one.

`SSHMessageReader` is the single choke point for both SSH messages and SFTP packets, so bounds checks there fix every decoder at once. After the change, all 36000 fuzz cases surface as `SSHPacketError`.

## And a real bug sitting next to it

`readBytes` indexed the underlying buffer rather than the message:

```dart
Uint8List.view(_byteData.buffer, _offset, length)
```

`readString`, three lines below, correctly uses `Uint8List.sublistView(data, ...)`. On a message that is a view into a larger buffer, which is exactly what every SSH and SFTP payload is, the two disagree. Demonstrated on a message living at offset 8 of its buffer:

```
message      : [160, 161, 162, 163, ...]
readBytes(4) : [238, 238, 238, 238]     <- the padding before the message
```

Only `OpenSSHKeyPairs.decode` calls it today, on a freshly base64-decoded blob whose `offsetInBytes` is zero, so nothing is broken in practice. It was a landmine for the next decoder to reach for it, and the failure mode is silent wrong bytes rather than an error.

## Tests

`test/src/message/decoder_fuzz_test.dart` runs both random bytes and valid messages truncated at every length through ten decoders, asserting anything thrown is an `SSHError`. Plus two direct tests on the reader: `readBytes` on a view, and reading past the end.

509 tests, analyze and format clean. The existing 505 all still pass, so the stricter errors did not change any behaviour that was already covered.
