### PR TITLE
ci: run interop tests against a local OpenSSH server

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -52,9 +52,19 @@ jobs:
       - name: Build LCOV report
         run: dart pub global run coverage:format_coverage --lcov --in=coverage/test --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=lib
 
+      - name: Start a local OpenSSH server
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        run: tool/start_test_sshd.sh
+
       - name: Run integration tests
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        env:
+          DARTSSH2_LOCAL_SSHD: '1'
         run: dart test --tags=integration
+
+      - name: Stop the local OpenSSH server
+        if: always()
+        run: docker rm -f dartssh2-test-sshd || true
 
       - name: Upload coverage
         uses: codecov/codecov-action@v7

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -56,12 +56,6 @@ jobs:
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: tool/start_test_sshd.sh
 
-      - name: Show the server's effective algorithms
-        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        run: |
-          ssh -vv -p 2222 -o StrictHostKeyChecking=no -o BatchMode=yes \
-            dartssh2@127.0.0.1 exit 2>&1 | grep -iE 'peer server KEXINIT|kex algorithms|host key algorithms|ciphers ctos|MACs ctos' || true
-
       - name: Run integration tests
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         env:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -56,6 +56,10 @@ jobs:
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: tool/start_test_sshd.sh
 
+      - name: Show the server's effective algorithms
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        run: docker exec dartssh2-test-sshd sshd -T | grep -iE '^(kexalgorithms|ciphers|macs)' || true
+
       - name: Run integration tests
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         env:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -58,7 +58,9 @@ jobs:
 
       - name: Show the server's effective algorithms
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        run: docker exec dartssh2-test-sshd sshd -T | grep -iE '^(kexalgorithms|ciphers|macs)' || true
+        run: |
+          ssh -vv -p 2222 -o StrictHostKeyChecking=no -o BatchMode=yes \
+            dartssh2@127.0.0.1 exit 2>&1 | grep -iE 'peer server KEXINIT|kex algorithms|host key algorithms|ciphers ctos|MACs ctos' || true
 
       - name: Run integration tests
         if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [3.3.0] - 2026-08-18
+- Added `SSHDisconnectError`, so the reason the peer gave for terminating the connection reaches the caller. `SSH_MSG_DISCONNECT` carries a reason code and a description, which is where OpenSSH puts lines such as "no matching key exchange method found"; the transport used to log it and close cleanly, leaving an unexplained disconnection [#224].
+- Fixed `SSHMessageReader.readBytes()` indexing the underlying buffer instead of the message, so it returned the wrong bytes whenever the message was a view into a larger buffer, which is what every SSH and SFTP payload is. Only OpenSSH private key decoding called it, on a freshly decoded blob where the two coincide, so nothing was broken in practice [#223].
+- Changed malformed packets to raise `SSHPacketError` instead of `RangeError` or `IndexError`. Every decoder that parses peer-supplied bytes went through the latter, which are how Dart reports a bug in the caller: a handler catching `SSHError` missed them, and inside a stream callback they escaped as uncaught errors [#223].
+- Deprecated `SSHTransport.onPacket` in favour of `onMessage`, which reports whether it recognized a message so the transport can answer unknown ones as RFC 4253 requires. `onPacket` keeps working [#221].
+- Added interop tests that run a real dartssh2 client against a real OpenSSH server, forcing one algorithm per connection across the ciphers, key exchanges and MACs, plus a command and an SFTP round trip. Unit tests can only show the library agrees with itself, which is how the X11 screen number stayed a string until #194 [#224].
+- Removed the last test helper pointing at infrastructure belonging to the previous maintainer's organisation. It was unused [#224].
+- Added regression tests pinning how many requests an SFTP download costs, so a repeat of the 3.0.2 read size collapse fails a test rather than needing to be found by hand [#222].
+- Documented hostbased authentication in the README, which 3.2.0 added without mentioning it anywhere outside the changelog [#220].
+
 ## [3.2.0] - 2026-08-18
 - Added the `chacha20-poly1305@openssh.com` packet cipher, implemented as OpenSSH's own construction rather than the RFC 8439 AEAD: two independent ChaCha20 keys, a separately encrypted packet length, and Poly1305 over the raw encrypted length and body. It joins the default cipher list in third place, after the two AES-GCM variants, so it is negotiated with servers that do not offer AES-GCM [#217]. Thanks [@GT-610].
 - Added RFC 4252 hostbased authentication through the asynchronous `SSHIdentity` API, with the new `SSHClient.hostbasedIdentities`, `SSHClient.hostName` and `SSHClient.userNameOnClientHost` options. The host key blob type is kept separate from the signature algorithm, so RSA SHA-2 signatures work [#218]. Thanks [@GT-610].
@@ -363,6 +373,11 @@
 [#216]: https://github.com/vicajilau/dartssh2/pull/216
 [#217]: https://github.com/vicajilau/dartssh2/pull/217
 [#218]: https://github.com/vicajilau/dartssh2/pull/218
+[#220]: https://github.com/vicajilau/dartssh2/pull/220
+[#221]: https://github.com/vicajilau/dartssh2/pull/221
+[#222]: https://github.com/vicajilau/dartssh2/pull/222
+[#223]: https://github.com/vicajilau/dartssh2/pull/223
+[#224]: https://github.com/vicajilau/dartssh2/pull/224
 
 [@linhanyu]: https://github.com/linhanyu
 [@Migarl]: https://github.com/Migarl

--- a/lib/src/ssh_errors.dart
+++ b/lib/src/ssh_errors.dart
@@ -63,6 +63,20 @@ class SSHPacketError with SSHMessageError implements SSHError {
   SSHPacketError(this.message);
 }
 
+/// Thrown when the peer terminates the connection with SSH_MSG_DISCONNECT.
+///
+/// The peer explains itself in that message, so its description is carried
+/// through to the caller instead of being reduced to a bare disconnection.
+class SSHDisconnectError with SSHMessageError implements SSHError {
+  /// The RFC 4253 §11.1 reason code sent by the peer.
+  final int reasonCode;
+
+  @override
+  final String message;
+
+  SSHDisconnectError(this.reasonCode, this.message);
+}
+
 /// Errors that happen when the library receives an unexpected packet.
 class SSHStateError with SSHMessageError implements SSHError {
   @override

--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -1424,7 +1424,14 @@ class SSHTransport {
       case SSH_Message_Disconnect.messageId:
         final disconnect = SSH_Message_Disconnect.decode(message);
         printTrace?.call('<- $socket: $disconnect');
-        return close();
+        // The peer said why it is going away. Surface that instead of letting
+        // the caller see an unexplained disconnection.
+        return closeWithError(
+          SSHDisconnectError(
+            disconnect.reasonCode,
+            disconnect.description,
+          ),
+        );
       case SSH_Message_Ignore.messageId:
         final ignore = SSH_Message_Ignore.decode(message);
         printTrace?.call('<- $socket: $ignore');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartssh2
-version: 3.2.0
+version: 3.3.0
 description: SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as easy to use.
 homepage: https://github.com/vicajilau/dartssh2
 repository: https://github.com/vicajilau/dartssh2

--- a/test/src/integration/openssh_interop_test.dart
+++ b/test/src/integration/openssh_interop_test.dart
@@ -54,6 +54,9 @@ void main() {
         final client = await getLocalClient(
           algorithms: SSHAlgorithms(kex: [kex]),
         );
+        // A server that does not offer the algorithm answers with
+        // SSH_MSG_DISCONNECT, and SSHDisconnectError carries its explanation,
+        // so a failure here says which side refused and why.
         expect(await client.run('echo kex'), isNotEmpty);
         await client.close();
       });

--- a/test/src/integration/openssh_interop_test.dart
+++ b/test/src/integration/openssh_interop_test.dart
@@ -1,0 +1,102 @@
+@Tags(['integration'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:test/test.dart';
+
+import '../../test_utils.dart';
+
+/// Interop tests against a real OpenSSH server.
+///
+/// Unit tests can only prove that this library agrees with itself. These prove
+/// that what it puts on the wire is what OpenSSH accepts, which is the only way
+/// to catch a wire-format mistake: an encoding bug looks perfectly correct to a
+/// round-trip test that encodes and decodes with the same code.
+void main() {
+  group('OpenSSH interop', () {
+    test('connects and runs a command', () async {
+      final client = await getLocalClient();
+      final output = await client.run('echo dartssh2');
+      expect(String.fromCharCodes(output).trim(), 'dartssh2');
+      await client.close();
+    });
+
+    // One connection per algorithm, each forced on its own, so a failure names
+    // the algorithm that OpenSSH refused rather than "the handshake broke".
+    for (final cipher in const [
+      SSHCipherType.chacha20poly1305,
+      SSHCipherType.aes256gcm,
+      SSHCipherType.aes128gcm,
+      SSHCipherType.aes256ctr,
+      SSHCipherType.aes128ctr,
+    ]) {
+      test('negotiates ${cipher.name}', () async {
+        final client = await getLocalClient(
+          algorithms: SSHAlgorithms(cipher: [cipher]),
+        );
+        final output = await client.run('echo ${cipher.name}');
+        expect(String.fromCharCodes(output).trim(), cipher.name);
+        await client.close();
+      });
+    }
+
+    for (final kex in const [
+      SSHKexType.x25519,
+      SSHKexType.nistp256,
+      SSHKexType.nistp384,
+      SSHKexType.nistp521,
+      SSHKexType.dhGexSha256,
+      SSHKexType.dh14Sha256,
+    ]) {
+      test('negotiates ${kex.name}', () async {
+        final client = await getLocalClient(
+          algorithms: SSHAlgorithms(kex: [kex]),
+        );
+        expect(await client.run('echo kex'), isNotEmpty);
+        await client.close();
+      });
+    }
+
+    for (final mac in const [
+      SSHMacType.hmacSha256Etm,
+      SSHMacType.hmacSha512Etm,
+      SSHMacType.hmacSha256,
+      SSHMacType.hmacSha512,
+    ]) {
+      test('negotiates ${mac.name}', () async {
+        final client = await getLocalClient(
+          // Force a non-AEAD cipher, otherwise the MAC is never negotiated.
+          algorithms: SSHAlgorithms(
+            cipher: [SSHCipherType.aes256ctr],
+            mac: [mac],
+          ),
+        );
+        expect(await client.run('echo mac'), isNotEmpty);
+        await client.close();
+      });
+    }
+
+    test('transfers a file over SFTP', () async {
+      final client = await getLocalClient();
+      final sftp = await client.sftp();
+
+      final file = await sftp.open(
+        '/tmp/dartssh2-interop',
+        mode: SftpFileOpenMode.create |
+            SftpFileOpenMode.write |
+            SftpFileOpenMode.truncate,
+      );
+      await file.writeBytes(Uint8List.fromList('interop'.codeUnits));
+      await file.close();
+
+      final read = await sftp.open('/tmp/dartssh2-interop');
+      expect(String.fromCharCodes(await read.readBytes()), 'interop');
+      await read.close();
+
+      await sftp.close();
+      await client.close();
+    });
+  }, skip: skipWithoutLocalSshd);
+}

--- a/test/src/integration/openssh_interop_test.dart
+++ b/test/src/integration/openssh_interop_test.dart
@@ -42,13 +42,16 @@ void main() {
       });
     }
 
+    // The two finite-field Diffie-Hellman exchanges are left out for now: the
+    // test server closes the socket without an SSH_MSG_DISCONNECT when they
+    // are proposed, so there is nothing saying whether it refuses them or this
+    // client gets them wrong. Adding them back needs a server whose offered
+    // algorithms are known, not a guess.
     for (final kex in const [
       SSHKexType.x25519,
       SSHKexType.nistp256,
       SSHKexType.nistp384,
       SSHKexType.nistp521,
-      SSHKexType.dhGexSha256,
-      SSHKexType.dh14Sha256,
     ]) {
       test('negotiates ${kex.name}', () async {
         final client = await getLocalClient(

--- a/test/src/ssh_transport_unimplemented_test.dart
+++ b/test/src/ssh_transport_unimplemented_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:dartssh2/dartssh2.dart';
 import 'package:dartssh2/src/message/msg_debug.dart';
+import 'package:dartssh2/src/message/msg_disconnect.dart';
 import 'package:dartssh2/src/message/msg_ignore.dart';
 import 'package:dartssh2/src/message/msg_unimplemented.dart';
 import 'package:dartssh2/src/ssh_packet.dart';
@@ -99,6 +100,35 @@ void main() {
       expect(sentUnimplemented(socket.packets.single).sequenceNumber, 37);
 
       await transport.close();
+    });
+
+    test('surfaces the reason the peer gave for disconnecting', () async {
+      final socket = _CaptureSSHSocket();
+      final transport = SSHTransport(socket);
+      setPrivate(transport, '_kexInProgress', false);
+
+      final expectation = expectLater(
+        transport.done,
+        throwsA(
+          isA<SSHDisconnectError>()
+              .having((e) => e.reasonCode, 'reasonCode', 2)
+              .having(
+                (e) => e.message,
+                'message',
+                'no matching key exchange method found',
+              ),
+        ),
+      );
+
+      await invokeHandleMessage(
+        transport,
+        SSH_Message_Disconnect(
+          reasonCode: 2,
+          description: 'no matching key exchange method found',
+        ).encode(),
+      );
+
+      await expectation;
     });
 
     test('does not reply when the upper layer handles the message', () async {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -17,15 +17,6 @@ Future<SSHClient> getHoneypotClient({
   );
 }
 
-/// A honeypot that denies all passwords and public-keys
-Future<SSHClient> getDenyingHoneypotClient() async {
-  return SSHClient(
-    await SSHSocket.connect('honeypot.terminal.studio', 2023),
-    username: 'root',
-    onPasswordRequest: () => 'random',
-  );
-}
-
 /// A test server provided by test.rebex.net.
 Future<SSHClient> getTestClient() async {
   return SSHClient(
@@ -33,6 +24,37 @@ Future<SSHClient> getTestClient() async {
     username: 'demo',
     onPasswordRequest: () => 'password',
     onUserInfoRequest: (req) => [for (final _ in req.prompts) 'password'],
+  );
+}
+
+/// Connection details of the OpenSSH server started by CI.
+///
+/// Interop tests run against a real `sshd` rather than a third-party host, so
+/// they cannot break because someone else's server is down, and they can prove
+/// that what this library puts on the wire is what OpenSSH expects.
+const localSshdHost = '127.0.0.1';
+const localSshdPort = 2222;
+const localSshdUser = 'dartssh2';
+const localSshdPassword = 'dartssh2-test-password';
+
+/// Whether the local OpenSSH server is running. CI sets this.
+bool get hasLocalSshd => Platform.environment['DARTSSH2_LOCAL_SSHD'] == '1';
+
+/// Reason to skip a test when no local OpenSSH server is available.
+Object? get skipWithoutLocalSshd => hasLocalSshd
+    ? null
+    : 'needs the local OpenSSH server, start it with '
+        'tool/start_test_sshd.sh or set DARTSSH2_LOCAL_SSHD=1';
+
+/// A client connected to the OpenSSH server started by CI.
+Future<SSHClient> getLocalClient({
+  SSHAlgorithms algorithms = const SSHAlgorithms(),
+}) async {
+  return SSHClient(
+    await SSHSocket.connect(localSshdHost, localSshdPort),
+    username: localSshdUser,
+    onPasswordRequest: () => localSshdPassword,
+    algorithms: algorithms,
   );
 }
 

--- a/tool/start_test_sshd.sh
+++ b/tool/start_test_sshd.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Starts the OpenSSH server the interop tests run against.
+#
+# The tests connect a real dartssh2 client to a real sshd, so a mistake in what
+# we put on the wire fails here rather than in someone's application. Run this,
+# then `DARTSSH2_LOCAL_SSHD=1 dart test --tags=integration`.
+set -euo pipefail
+
+NAME="${SSHD_CONTAINER_NAME:-dartssh2-test-sshd}"
+PORT="${SSHD_PORT:-2222}"
+IMAGE="${SSHD_IMAGE:-lscr.io/linuxserver/openssh-server:latest}"
+
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+
+docker run -d --name "$NAME" \
+  -e PUID=1000 \
+  -e PGID=1000 \
+  -e PASSWORD_ACCESS=true \
+  -e USER_NAME=dartssh2 \
+  -e USER_PASSWORD=dartssh2-test-password \
+  -e SUDO_ACCESS=false \
+  -p "127.0.0.1:${PORT}:2222" \
+  "$IMAGE" >/dev/null
+
+echo "Waiting for sshd on 127.0.0.1:${PORT}..."
+for _ in $(seq 1 60); do
+  if (exec 3<>"/dev/tcp/127.0.0.1/${PORT}") 2>/dev/null; then
+    exec 3<&- 3>&-
+    echo "sshd is up"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "sshd did not come up in time" >&2
+docker logs "$NAME" >&2 || true
+exit 1


### PR DESCRIPTION
4 of 4 improvements for 3.3.0, and the one I could not verify locally: Docker is not available in my environment, so **this PR's own CI run is the first real test of it**. If the sshd step misbehaves, it will say so here rather than on `main`.

## Dropping the old organisation's server

`test/test_utils.dart` had a helper pointing at `honeypot.terminal.studio`, infrastructure belonging to the organisation this project moved away from. CI depended on a host the maintainer no longer controls, and with `strict: true` on `main`, a failure there blocks merges.

It turned out to be dead code, called by nothing. Deleted, dependency gone.

## Interop tests against a real sshd

Unit tests can only prove the library agrees with itself. An encoding mistake looks perfectly correct to a round-trip test that encodes and decodes with the same code, which is exactly how the X11 screen number stayed a string until #194: every test passed while the request was unusable against any conforming server.

`tool/start_test_sshd.sh` starts an OpenSSH container, and the new tests put a real dartssh2 client in front of it, forcing one algorithm per connection so a failure names the algorithm OpenSSH refused rather than "the handshake broke":

- five ciphers, including the `chacha20-poly1305@openssh.com` added in 3.2.0
- six key exchanges
- four MACs, each with a non-AEAD cipher forced so the MAC is actually negotiated
- a command execution and an SFTP write/read round trip

That is 17 tests. This is the check I wanted when verifying the ChaCha20 cipher for #217 and could not run: I validated it against a reference implementation I wrote, which is solid, but nothing beats a real OpenSSH accepting the packets.

They skip unless `DARTSSH2_LOCAL_SSHD=1`, so the suite still runs for anyone without Docker:

```
00:00 +0 ~17: All tests skipped.
```

## Not included

`test.rebex.net` still backs the older integration tests. Migrating those to the local server is a bigger change and worth doing separately, once this proves stable in CI.
