### PR TITLE
test: build the interop server so its algorithms are known

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Fixed `SSHMessageReader.readBytes()` indexing the underlying buffer instead of the message, so it returned the wrong bytes whenever the message was a view into a larger buffer, which is what every SSH and SFTP payload is. Only OpenSSH private key decoding called it, on a freshly decoded blob where the two coincide, so nothing was broken in practice [#223].
 - Changed malformed packets to raise `SSHPacketError` instead of `RangeError` or `IndexError`. Every decoder that parses peer-supplied bytes went through the latter, which are how Dart reports a bug in the caller: a handler catching `SSHError` missed them, and inside a stream callback they escaped as uncaught errors [#223].
 - Deprecated `SSHTransport.onPacket` in favour of `onMessage`, which reports whether it recognized a message so the transport can answer unknown ones as RFC 4253 requires. `onPacket` keeps working [#221].
-- Added interop tests that run a real dartssh2 client against a real OpenSSH server, forcing one algorithm per connection across the ciphers, key exchanges and MACs, plus a command and an SFTP round trip. Unit tests can only show the library agrees with itself, which is how the X11 screen number stayed a string until #194 [#224].
+- Added interop tests that run a real dartssh2 client against a real OpenSSH server, forcing one algorithm per connection across the ciphers, key exchanges and MACs, plus a command and an SFTP round trip. Unit tests can only show the library agrees with itself, which is how the X11 screen number stayed a string until #194 [#224] [#225].
 - Removed the last test helper pointing at infrastructure belonging to the previous maintainer's organisation. It was unused [#224].
 - Added regression tests pinning how many requests an SFTP download costs, so a repeat of the 3.0.2 read size collapse fails a test rather than needing to be found by hand [#222].
 - Documented hostbased authentication in the README, which 3.2.0 added without mentioning it anywhere outside the changelog [#220].
@@ -378,6 +378,7 @@
 [#222]: https://github.com/vicajilau/dartssh2/pull/222
 [#223]: https://github.com/vicajilau/dartssh2/pull/223
 [#224]: https://github.com/vicajilau/dartssh2/pull/224
+[#225]: https://github.com/vicajilau/dartssh2/pull/225
 
 [@linhanyu]: https://github.com/linhanyu
 [@Migarl]: https://github.com/Migarl

--- a/test/src/integration/openssh_interop_test.dart
+++ b/test/src/integration/openssh_interop_test.dart
@@ -42,16 +42,13 @@ void main() {
       });
     }
 
-    // The two finite-field Diffie-Hellman exchanges are left out for now: the
-    // test server closes the socket without an SSH_MSG_DISCONNECT when they
-    // are proposed, so there is nothing saying whether it refuses them or this
-    // client gets them wrong. Adding them back needs a server whose offered
-    // algorithms are known, not a guess.
     for (final kex in const [
       SSHKexType.x25519,
       SSHKexType.nistp256,
       SSHKexType.nistp384,
       SSHKexType.nistp521,
+      SSHKexType.dhGexSha256,
+      SSHKexType.dh14Sha256,
     ]) {
       test('negotiates ${kex.name}', () async {
         final client = await getLocalClient(

--- a/tool/start_test_sshd.sh
+++ b/tool/start_test_sshd.sh
@@ -1,32 +1,28 @@
 #!/usr/bin/env bash
-# Starts the OpenSSH server the interop tests run against.
+# Builds and starts the OpenSSH server the interop tests run against.
 #
-# The tests connect a real dartssh2 client to a real sshd, so a mistake in what
-# we put on the wire fails here rather than in someone's application. Run this,
-# then `DARTSSH2_LOCAL_SSHD=1 dart test --tags=integration`.
+# The image is built from tool/test-sshd so the algorithms the server offers
+# are known exactly. Run this, then:
+#
+#   DARTSSH2_LOCAL_SSHD=1 dart test --tags=integration
 set -euo pipefail
 
 NAME="${SSHD_CONTAINER_NAME:-dartssh2-test-sshd}"
 PORT="${SSHD_PORT:-2222}"
-IMAGE="${SSHD_IMAGE:-lscr.io/linuxserver/openssh-server:latest}"
+TAG="${SSHD_IMAGE_TAG:-dartssh2-test-sshd:local}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 docker rm -f "$NAME" >/dev/null 2>&1 || true
-
-docker run -d --name "$NAME" \
-  -e PUID=1000 \
-  -e PGID=1000 \
-  -e PASSWORD_ACCESS=true \
-  -e USER_NAME=dartssh2 \
-  -e USER_PASSWORD=dartssh2-test-password \
-  -e SUDO_ACCESS=false \
-  -p "127.0.0.1:${PORT}:2222" \
-  "$IMAGE" >/dev/null
+docker build -t "$TAG" "$HERE/test-sshd"
+docker run -d --name "$NAME" -p "127.0.0.1:${PORT}:2222" "$TAG" >/dev/null
 
 echo "Waiting for sshd on 127.0.0.1:${PORT}..."
 for _ in $(seq 1 60); do
   if (exec 3<>"/dev/tcp/127.0.0.1/${PORT}") 2>/dev/null; then
     exec 3<&- 3>&-
-    echo "sshd is up"
+    echo "sshd is up. Algorithms it offers:"
+    docker exec "$NAME" /usr/sbin/sshd -T -f /etc/ssh/sshd_config \
+      | grep -iE '^(kexalgorithms|ciphers|macs) '
     exit 0
   fi
   sleep 1

--- a/tool/test-sshd/Dockerfile
+++ b/tool/test-sshd/Dockerfile
@@ -1,0 +1,17 @@
+# The OpenSSH server the interop tests run against.
+#
+# Built here rather than pulled from a general purpose image so the offered
+# algorithms are known exactly. When a test fails, that leaves only one
+# explanation: this client got the algorithm wrong.
+FROM alpine:3.20
+
+RUN apk add --no-cache openssh-server openssh-sftp-server \
+    && ssh-keygen -A \
+    && adduser -D -s /bin/sh dartssh2 \
+    && echo 'dartssh2:dartssh2-test-password' | chpasswd
+
+COPY sshd_config /etc/ssh/sshd_config
+
+EXPOSE 2222
+
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/tool/test-sshd/sshd_config
+++ b/tool/test-sshd/sshd_config
@@ -1,0 +1,25 @@
+# Deliberately explicit: every algorithm the interop matrix exercises is listed
+# here, so a handshake failure means the client is wrong, never that the server
+# quietly dropped support for something.
+
+Port 2222
+ListenAddress 0.0.0.0
+
+PasswordAuthentication yes
+PermitRootLogin no
+PermitEmptyPasswords no
+UsePAM no
+
+HostKey /etc/ssh/ssh_host_ed25519_key
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+
+KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256
+
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+
+MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
+
+Subsystem sftp /usr/lib/ssh/sftp-server
+
+LogLevel VERBOSE


### PR DESCRIPTION
Follow-up to #224, closing the question it left open.

#224 dropped `diffie-hellman-group-exchange-sha256` and `diffie-hellman-group14-sha256` from the interop matrix because I could not explain their failure. The server was `lscr.io/linuxserver/openssh-server`, a general purpose image whose defaults are not ours, and it closed the socket without an `SSH_MSG_DISCONNECT`, so a server refusing the algorithm and this client getting it wrong looked exactly the same from outside. Three attempts at reading the server's configuration from CI produced no output at all.

Guessing was the one thing I did not want to do in a security library, so the fix is to remove the ambiguity rather than the tests.

## The server is now ours

`tool/test-sshd/` builds it: Alpine, `openssh-server`, and an `sshd_config` that names every algorithm the matrix exercises.

```
KexAlgorithms curve25519-sha256,...,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256
Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,...
MACs hmac-sha2-256-etm@openssh.com,...
```

If a handshake fails now there is one explanation left, which is the whole point of an interop test. The start script also prints the server's effective algorithms via `sshd -T`, so the log settles the question without another round trip.

Both exchanges are back in the matrix, taking it from 15 tests to 17.

## Note

This started as a commit on #224's branch but arrived after it was merged, so it comes as its own PR. The 3.3.0 changelog entry for the interop tests is extended rather than duplicated.
