### PR TITLE
fix: stop offloading elliptic curve key exchange to isolates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.3.1] - 2026-08-19
+- Removed the background isolate offload from X25519 and NIST curve key exchange, which cost more than the work it was hiding. Generating an ephemeral key or computing the shared secret on these curves is one fixed-size scalar multiply, well under a millisecond, while `Isolate.run` takes several times that to spawn and tear down, and a client pays it twice per handshake. On a memory constrained Android device the spawn delay was long enough for the server to time out the key exchange and close the connection before `SSH_MSG_NEWKEYS` went out, surfacing as `SSHAuthAbortError` with a null reason [#226]. Thanks [@cesarcamps].
+- Kept the offload for finite field Diffie-Hellman, which is the one exchange whose cost the peer controls: group exchange lets the server name a modulus of up to 8192 bits, and modular exponentiation grows steeply with it.
+- Added debug logging around host key signature verification and the `onVerifyHostKey` callback. Everything between receiving the key exchange reply and sending `SSH_MSG_NEWKEYS` used to run without a single `printDebug` call, so a slow user callback and a slow shared secret were indistinguishable in a trace, and both looked like a hung handshake [#226].
+
 ## [3.3.0] - 2026-08-18
 - Added `SSHDisconnectError`, so the reason the peer gave for terminating the connection reaches the caller. `SSH_MSG_DISCONNECT` carries a reason code and a description, which is where OpenSSH puts lines such as "no matching key exchange method found"; the transport used to log it and close cleanly, leaving an unexplained disconnection [#224].
 - Fixed `SSHMessageReader.readBytes()` indexing the underlying buffer instead of the message, so it returned the wrong bytes whenever the message was a view into a larger buffer, which is what every SSH and SFTP payload is. Only OpenSSH private key decoding called it, on a freshly decoded blob where the two coincide, so nothing was broken in practice [#223].
@@ -379,6 +384,7 @@
 [#223]: https://github.com/vicajilau/dartssh2/pull/223
 [#224]: https://github.com/vicajilau/dartssh2/pull/224
 [#225]: https://github.com/vicajilau/dartssh2/pull/225
+[#226]: https://github.com/vicajilau/dartssh2/issues/226
 
 [@linhanyu]: https://github.com/linhanyu
 [@Migarl]: https://github.com/Migarl
@@ -397,3 +403,4 @@
 [@gkc]: https://github.com/gkc
 [@vicajilau]: https://github.com/vicajilau
 [@GT-610]: https://github.com/GT-610
+[@cesarcamps]: https://github.com/cesarcamps

--- a/lib/src/kex/kex_nist.dart
+++ b/lib/src/kex/kex_nist.dart
@@ -2,7 +2,6 @@ import 'dart:typed_data';
 
 import 'package:dartssh2/src/kex/private_scalar.dart';
 import 'package:dartssh2/src/ssh_kex.dart';
-import 'package:dartssh2/src/utils/compute.dart';
 import 'package:pointycastle/ecc/curves/secp256r1.dart';
 import 'package:pointycastle/ecc/curves/secp384r1.dart';
 import 'package:pointycastle/ecc/curves/secp521r1.dart';
@@ -31,37 +30,11 @@ class SSHKexNist implements SSHKexECDH {
     publicKey = c!.getEncoded(false);
   }
 
-  SSHKexNist._({
-    required this.curve,
-    required this.secretBits,
-    required this.privateKey,
-    required this.publicKey,
-  });
-
   SSHKexNist.p256() : this(curve: ECCurve_secp256r1(), secretBits: 256);
 
   SSHKexNist.p384() : this(curve: ECCurve_secp384r1(), secretBits: 384);
 
   SSHKexNist.p521() : this(curve: ECCurve_secp521r1(), secretBits: 521);
-
-  static Future<SSHKexNist> p256Async() => createAsync('p256');
-
-  static Future<SSHKexNist> p384Async() => createAsync('p384');
-
-  static Future<SSHKexNist> p521Async() => createAsync('p521');
-
-  static Future<SSHKexNist> createAsync(String curveName) async {
-    final (privateKey, publicKey) =
-        await sshCompute(_computeNistKeyPair, curveName);
-    final curve = _getCurveByName(curveName);
-    final secretBits = _getSecretBitsByName(curveName);
-    return SSHKexNist._(
-      curve: curve,
-      secretBits: secretBits,
-      privateKey: privateKey,
-      publicKey: publicKey,
-    );
-  }
 
   /// Compute shared secret.
   @override
@@ -69,65 +42,4 @@ class SSHKexNist implements SSHKexECDH {
     final s = curve.curve.decodePoint(remotePubilcKey)!;
     return (s * privateKey)!.x!.toBigInteger()!;
   }
-
-  Future<BigInt> computeSecretAsync(Uint8List remotePublicKey) async {
-    final curveName = _getNameByCurve(curve);
-    return sshCompute(
-      _computeNistSecret,
-      (curveName, privateKey, remotePublicKey),
-    );
-  }
-}
-
-ECDomainParameters _getCurveByName(String name) {
-  switch (name) {
-    case 'p256':
-      return ECCurve_secp256r1();
-    case 'p384':
-      return ECCurve_secp384r1();
-    case 'p521':
-      return ECCurve_secp521r1();
-    default:
-      throw ArgumentError('Unknown curve name: $name');
-  }
-}
-
-int _getSecretBitsByName(String name) {
-  switch (name) {
-    case 'p256':
-      return 256;
-    case 'p384':
-      return 384;
-    case 'p521':
-      return 521;
-    default:
-      throw ArgumentError('Unknown curve name: $name');
-  }
-}
-
-String _getNameByCurve(ECDomainParameters curve) {
-  if (curve is ECCurve_secp256r1) return 'p256';
-  if (curve is ECCurve_secp384r1) return 'p384';
-  if (curve is ECCurve_secp521r1) return 'p521';
-  throw ArgumentError('Unknown curve type: $curve');
-}
-
-(BigInt, Uint8List) _computeNistKeyPair(String curveName) {
-  final curve = _getCurveByName(curveName);
-  final x = generateEcPrivateScalar(curve.n);
-
-  final c = curve.G * x;
-  final publicKey = c!.getEncoded(false);
-
-  return (x, publicKey);
-}
-
-BigInt _computeNistSecret((String, BigInt, Uint8List) args) {
-  final curveName = args.$1;
-  final privateKey = args.$2;
-  final remotePublicKey = args.$3;
-
-  final curve = _getCurveByName(curveName);
-  final s = curve.curve.decodePoint(remotePublicKey)!;
-  return (s * privateKey)!.x!.toBigInteger()!;
 }

--- a/lib/src/kex/kex_x25519.dart
+++ b/lib/src/kex/kex_x25519.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:dartssh2/src/ssh_kex.dart';
-import 'package:dartssh2/src/utils/compute.dart';
 import 'package:dartssh2/src/utils/bigint.dart';
 import 'package:dartssh2/src/utils/list.dart';
 import 'package:pinenacl/tweetnacl.dart';
@@ -25,38 +24,11 @@ class SSHKexX25519 implements SSHKexECDH {
 
   SSHKexX25519._({required this.privateKey, required this.publicKey});
 
-  static Future<SSHKexX25519> createAsync() async {
-    final (privateKey, publicKey) =
-        await sshCompute(_computeX25519KeyPair, null);
-    return SSHKexX25519._(
-      privateKey: privateKey,
-      publicKey: publicKey,
-    );
-  }
-
   @override
   BigInt computeSecret(Uint8List remotePublicKey) {
     final secret = _ScalarMult.scalseMult(privateKey, remotePublicKey);
     return decodeBigIntWithSign(1, secret);
   }
-
-  Future<BigInt> computeSecretAsync(Uint8List remotePublicKey) async {
-    final secret = await sshCompute(
-      _computeX25519Secret,
-      (privateKey, remotePublicKey),
-    );
-    return decodeBigIntWithSign(1, secret);
-  }
-}
-
-(Uint8List, Uint8List) _computeX25519KeyPair(void _) {
-  final privateKey = randomBytes(32);
-  final publicKey = _ScalarMult.scalseMultBase(privateKey);
-  return (privateKey, publicKey);
-}
-
-Uint8List _computeX25519Secret((Uint8List, Uint8List) data) {
-  return _ScalarMult.scalseMult(data.$1, data.$2);
 }
 
 /// Scalar multiplication, Implements curve25519.

--- a/lib/src/ssh_transport.dart
+++ b/lib/src/ssh_transport.dart
@@ -1650,19 +1650,27 @@ class SSHTransport {
     printDebug?.call('SSHTransport._serverMacType: $_serverMacType');
 
     switch (_kexType) {
+      // Elliptic curve key generation is a single fixed-size scalar multiply,
+      // well under a millisecond. Spawning an isolate for it costs several
+      // times more than the work it offloads, and the server is timing our
+      // handshake while we pay it, so it stays on this isolate.
       case SSHKexType.x25519:
       case SSHKexType.x25519Rfc:
-        _kex = await SSHKexX25519.createAsync();
+        _kex = SSHKexX25519();
         break;
       case SSHKexType.nistp256:
-        _kex = await SSHKexNist.p256Async();
+        _kex = SSHKexNist.p256();
         break;
       case SSHKexType.nistp384:
-        _kex = await SSHKexNist.p384Async();
+        _kex = SSHKexNist.p384();
         break;
       case SSHKexType.nistp521:
-        _kex = await SSHKexNist.p521Async();
+        _kex = SSHKexNist.p521();
         break;
+      // Finite field Diffie-Hellman is the one exchange whose cost the server
+      // controls: group exchange lets it name a modulus up to 8192 bits, and
+      // modular exponentiation grows steeply with that size. These stay
+      // offloaded so a large group cannot block the calling isolate.
       case SSHKexType.dh14Sha1:
       case SSHKexType.dh14Sha256:
         _kex = await SSHKexDH.group14Async();
@@ -1728,13 +1736,7 @@ class SSHTransport {
       hostSignature = message.signature;
       serverKexKey = message.ecdhPublicKey;
       clientKexKey = kex.publicKey;
-      if (kex is SSHKexX25519) {
-        sharedSecret = await kex.computeSecretAsync(message.ecdhPublicKey);
-      } else if (kex is SSHKexNist) {
-        sharedSecret = await kex.computeSecretAsync(message.ecdhPublicKey);
-      } else {
-        sharedSecret = kex.computeSecret(message.ecdhPublicKey);
-      }
+      sharedSecret = kex.computeSecret(message.ecdhPublicKey);
     } else {
       throw UnimplementedError('$kex');
     }
@@ -1753,6 +1755,7 @@ class SSHTransport {
     );
 
     if (!disableHostkeyVerification) {
+      printDebug?.call('SSHTransport._verifyHostkey');
       final verified = _verifyHostkey(
         keyBytes: hostkey,
         signatureBytes: hostSignature,
@@ -1773,9 +1776,14 @@ class SSHTransport {
       return;
     }
 
+    // The server is waiting for our NEWKEYS while this runs, and a slow
+    // callback here has already been mistaken for a hung key exchange, so
+    // bracket it in the debug log rather than leaving a silent gap.
+    printDebug?.call('SSHTransport.onVerifyHostKey');
     final userVerified = onVerifyHostKey != null
         ? await Future.value(onVerifyHostKey!(_hostkeyType!.name, fingerprint))
         : true;
+    printDebug?.call('SSHTransport.onVerifyHostKey = $userVerified');
 
     if (!userVerified) {
       closeWithError(SSHHostkeyError('Hostkey verification failed'));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartssh2
-version: 3.3.0
+version: 3.3.1
 description: SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as easy to use.
 homepage: https://github.com/vicajilau/dartssh2
 repository: https://github.com/vicajilau/dartssh2

--- a/test/src/kex/kex_nist_test.dart
+++ b/test/src/kex/kex_nist_test.dart
@@ -74,41 +74,4 @@ void main() {
       expect(kex.privateKey, lessThan(kex.curve.n));
     });
   });
-
-  group('SSHKexNist (Async)', () {
-    test('generate keys and compute shared secret asynchronously (P-256)',
-        () async {
-      final kex1 = await SSHKexNist.p256Async();
-      final kex2 = await SSHKexNist.p256Async();
-      final secret1 = await kex1.computeSecretAsync(kex2.publicKey);
-      final secret2 = await kex2.computeSecretAsync(kex1.publicKey);
-      expect(secret1, equals(secret2));
-    });
-
-    test('generate keys and compute shared secret asynchronously (P-384)',
-        () async {
-      final kex1 = await SSHKexNist.p384Async();
-      final kex2 = await SSHKexNist.p384Async();
-      final secret1 = await kex1.computeSecretAsync(kex2.publicKey);
-      final secret2 = await kex2.computeSecretAsync(kex1.publicKey);
-      expect(secret1, equals(secret2));
-    });
-
-    test('generate keys and compute shared secret asynchronously (P-521)',
-        () async {
-      final kex1 = await SSHKexNist.p521Async();
-      final kex2 = await SSHKexNist.p521Async();
-      final secret1 = await kex1.computeSecretAsync(kex2.publicKey);
-      final secret2 = await kex2.computeSecretAsync(kex1.publicKey);
-      expect(secret1, equals(secret2));
-    });
-
-    test('generate P-521 private key within valid range asynchronously',
-        () async {
-      final kex = await SSHKexNist.p521Async();
-
-      expect(kex.privateKey, greaterThan(BigInt.zero));
-      expect(kex.privateKey, lessThan(kex.curve.n));
-    });
-  });
 }

--- a/test/src/kex/kex_x25519_test.dart
+++ b/test/src/kex/kex_x25519_test.dart
@@ -61,17 +61,4 @@ void main() {
       expect(validSharedSecret.bitLength, greaterThan(0));
     });
   });
-
-  group('SSHKexX25519 (Async)', () {
-    test('generate keys and compute shared secret asynchronously', () async {
-      final kex1 = await SSHKexX25519.createAsync();
-      final kex2 = await SSHKexX25519.createAsync();
-      expect(kex1.privateKey.length, equals(32));
-      expect(kex1.publicKey.length, equals(32));
-
-      final secret1 = await kex1.computeSecretAsync(kex2.publicKey);
-      final secret2 = await kex2.computeSecretAsync(kex1.publicKey);
-      expect(secret1, equals(secret2));
-    });
-  });
 }


### PR DESCRIPTION
Fixes #226.

Generating an ephemeral X25519 or NIST curve key and computing the shared secret is one fixed-size scalar multiply. `Isolate.run` costs several times more than that to spawn and tear down, and a client pays it twice per handshake, so the offload added in 2.20.0 made these exchanges slower rather than smoother.

Measured on desktop with a warm JIT:

```
x25519 scalar multiply   0.76 ms
Isolate.run round trip   3.71 ms
DH group14 keygen        0.88 ms
DH group14 secret        0.67 ms
```

On a memory constrained Android device the spawn delay was long enough for the server to time out the key exchange and close the connection before `SSH_MSG_NEWKEYS` went out. That surfaced as `SSHAuthAbortError` with a null reason, which reads like a generic auth failure and gives no hint that it is a timing problem.

## Changes

- X25519 and NIST P-256/384/521 generate keys and compute the shared secret on the calling isolate. The async variants are removed rather than left as dead code for someone to wire back up.
- Finite field Diffie-Hellman keeps the offload. It is the one exchange whose cost the peer controls, since group exchange lets the server name a modulus of up to 8192 bits and modular exponentiation grows steeply with it.
- `printDebug` now brackets host key signature verification and the `onVerifyHostKey` callback. Everything between receiving the key exchange reply and sending `SSH_MSG_NEWKEYS` used to run without a single debug line, so a slow shared secret, a slow signature check and a slow user callback were indistinguishable in a trace, and all three looked like a hung handshake.

## Why not a flag

The issue suggested making the offload opt-out. This is not something callers should have had to opt out of, and a constructor flag would be permanent public API compensating for a bad default. An isolate pool would be over-engineering for sub-millisecond work.

## Testing

Analyzer clean, formatting clean, unit tests pass. The interop suite forces all six KEX types against a real OpenSSH server and covers every path touched here, but it needs CI to run: it is excluded from the default `dart test` run by the `integration` tag.

The reporter has confirmed the branch fixes their case against Bitvise SSH Server 7.38.
